### PR TITLE
Add Claimy town and mall claiming plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,51 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.controlbro</groupId>
+    <artifactId>claimy</artifactId>
+    <version>1.0.0</version>
+    <packaging>jar</packaging>
+
+    <name>Claimy</name>
+
+    <properties>
+        <java.version>21</java.version>
+        <paper.version>1.21.1-R0.1-SNAPSHOT</paper.version>
+    </properties>
+
+    <repositories>
+        <repository>
+            <id>papermc</id>
+            <url>https://repo.papermc.io/repository/maven-public/</url>
+        </repository>
+    </repositories>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.papermc.paper</groupId>
+            <artifactId>paper-api</artifactId>
+            <version>${paper.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.github.MilkBowl</groupId>
+            <artifactId>VaultAPI</artifactId>
+            <version>1.7</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.11.0</version>
+                <configuration>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/main/java/com/controlbro/claimy/ClaimyPlugin.java
+++ b/src/main/java/com/controlbro/claimy/ClaimyPlugin.java
@@ -1,0 +1,77 @@
+package com.controlbro.claimy;
+
+import com.controlbro.claimy.commands.MallCommand;
+import com.controlbro.claimy.commands.StuckCommand;
+import com.controlbro.claimy.commands.TownAdminCommand;
+import com.controlbro.claimy.commands.TownCommand;
+import com.controlbro.claimy.gui.TownGui;
+import com.controlbro.claimy.listeners.ProtectionListener;
+import com.controlbro.claimy.managers.MallManager;
+import com.controlbro.claimy.managers.TownManager;
+import net.milkbowl.vault.economy.Economy;
+import org.bukkit.Bukkit;
+import org.bukkit.plugin.RegisteredServiceProvider;
+import org.bukkit.plugin.java.JavaPlugin;
+
+public class ClaimyPlugin extends JavaPlugin {
+    private TownManager townManager;
+    private MallManager mallManager;
+    private TownGui townGui;
+    private Economy economy;
+
+    @Override
+    public void onEnable() {
+        saveDefaultConfig();
+        saveResource("gui.yml", false);
+
+        this.townManager = new TownManager(this);
+        this.mallManager = new MallManager(this);
+        this.townGui = new TownGui(this);
+
+        if (!setupEconomy()) {
+            getLogger().warning("Vault economy not found. Economy features will be disabled.");
+        }
+
+        Bukkit.getPluginManager().registerEvents(new ProtectionListener(this), this);
+        Bukkit.getPluginManager().registerEvents(townGui, this);
+
+        getCommand("town").setExecutor(new TownCommand(this));
+        getCommand("townadmin").setExecutor(new TownAdminCommand(this));
+        getCommand("mall").setExecutor(new MallCommand(this));
+        getCommand("stuck").setExecutor(new StuckCommand(this));
+    }
+
+    @Override
+    public void onDisable() {
+        townManager.save();
+        mallManager.save();
+    }
+
+    private boolean setupEconomy() {
+        if (getServer().getPluginManager().getPlugin("Vault") == null) {
+            return false;
+        }
+        RegisteredServiceProvider<Economy> rsp = getServer().getServicesManager().getRegistration(Economy.class);
+        if (rsp == null) {
+            return false;
+        }
+        economy = rsp.getProvider();
+        return economy != null;
+    }
+
+    public TownManager getTownManager() {
+        return townManager;
+    }
+
+    public MallManager getMallManager() {
+        return mallManager;
+    }
+
+    public TownGui getTownGui() {
+        return townGui;
+    }
+
+    public Economy getEconomy() {
+        return economy;
+    }
+}

--- a/src/main/java/com/controlbro/claimy/commands/MallCommand.java
+++ b/src/main/java/com/controlbro/claimy/commands/MallCommand.java
@@ -1,0 +1,47 @@
+package com.controlbro.claimy.commands;
+
+import com.controlbro.claimy.ClaimyPlugin;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+public class MallCommand implements CommandExecutor {
+    private final ClaimyPlugin plugin;
+
+    public MallCommand(ClaimyPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player player)) {
+            sender.sendMessage("Players only.");
+            return true;
+        }
+        if (args.length < 2 || !args[0].equalsIgnoreCase("claim")) {
+            sender.sendMessage("/mall claim <id>");
+            return true;
+        }
+        int id;
+        try {
+            id = Integer.parseInt(args[1]);
+        } catch (NumberFormatException ex) {
+            player.sendMessage("Invalid plot id.");
+            return true;
+        }
+        if (plugin.getConfig().getBoolean("settings.mall.require-town-for-mall-claim")) {
+            if (plugin.getTownManager().getTown(player.getUniqueId()).isEmpty()) {
+                player.sendMessage("You must be in a town to claim a mall plot.");
+                return true;
+            }
+        }
+        boolean claimed = plugin.getMallManager().claimPlot(id, player.getUniqueId());
+        if (claimed) {
+            player.sendMessage("Mall plot " + id + " claimed.");
+        } else {
+            player.sendMessage("Mall plot cannot be claimed.");
+        }
+        return true;
+    }
+}

--- a/src/main/java/com/controlbro/claimy/commands/StuckCommand.java
+++ b/src/main/java/com/controlbro/claimy/commands/StuckCommand.java
@@ -1,0 +1,64 @@
+package com.controlbro.claimy.commands;
+
+import com.controlbro.claimy.ClaimyPlugin;
+import com.controlbro.claimy.model.Town;
+import com.controlbro.claimy.util.MessageUtil;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+import java.util.Optional;
+
+public class StuckCommand implements CommandExecutor {
+    private final ClaimyPlugin plugin;
+
+    public StuckCommand(ClaimyPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player player)) {
+            sender.sendMessage("Players only.");
+            return true;
+        }
+        Optional<Town> townOptional = plugin.getTownManager().getTownAt(player.getLocation());
+        if (townOptional.isEmpty()) {
+            player.sendMessage("You are not inside a claim.");
+            return true;
+        }
+        Location location = findOutside(player.getLocation());
+        if (location == null) {
+            player.sendMessage("No safe location found.");
+            return true;
+        }
+        player.teleport(location);
+        MessageUtil.send(plugin, player, "stuck-teleported");
+        return true;
+    }
+
+    private Location findOutside(Location location) {
+        World world = location.getWorld();
+        int chunkX = location.getChunk().getX();
+        int chunkZ = location.getChunk().getZ();
+        int blockX = location.getBlockX();
+        int blockZ = location.getBlockZ();
+        int minX = chunkX << 4;
+        int minZ = chunkZ << 4;
+        int maxX = minX + 15;
+        int maxZ = minZ + 15;
+        int outsideX = blockX - minX < maxX - blockX ? minX - 1 : maxX + 1;
+        int outsideZ = blockZ - minZ < maxZ - blockZ ? minZ - 1 : maxZ + 1;
+        Location candidate = new Location(world, outsideX + 0.5, location.getY(), blockZ + 0.5);
+        if (world.getChunkAt(candidate).isLoaded()) {
+            candidate.setY(world.getHighestBlockYAt(candidate) + 1);
+            return candidate;
+        }
+        Location candidateZ = new Location(world, blockX + 0.5, location.getY(), outsideZ + 0.5);
+        candidateZ.setY(world.getHighestBlockYAt(candidateZ) + 1);
+        return candidateZ;
+    }
+}

--- a/src/main/java/com/controlbro/claimy/commands/TownAdminCommand.java
+++ b/src/main/java/com/controlbro/claimy/commands/TownAdminCommand.java
@@ -1,0 +1,63 @@
+package com.controlbro.claimy.commands;
+
+import com.controlbro.claimy.ClaimyPlugin;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+public class TownAdminCommand implements CommandExecutor {
+    private final ClaimyPlugin plugin;
+
+    public TownAdminCommand(ClaimyPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!sender.hasPermission("claimy.admin")) {
+            sender.sendMessage("No permission.");
+            return true;
+        }
+        if (args.length == 0) {
+            sender.sendMessage("/townadmin reload | /townadmin mall setplot <id> | /townadmin mall clear <id>");
+            return true;
+        }
+        if (args[0].equalsIgnoreCase("reload")) {
+            plugin.getTownManager().reload();
+            plugin.getMallManager().load();
+            plugin.getTownGui().reload();
+            sender.sendMessage("Claimy reloaded.");
+            return true;
+        }
+        if (args[0].equalsIgnoreCase("mall")) {
+            if (!(sender instanceof Player player)) {
+                sender.sendMessage("Players only.");
+                return true;
+            }
+            if (args.length < 3) {
+                sender.sendMessage("/townadmin mall setplot <id> | /townadmin mall clear <id>");
+                return true;
+            }
+            String action = args[1];
+            int id;
+            try {
+                id = Integer.parseInt(args[2]);
+            } catch (NumberFormatException ex) {
+                sender.sendMessage("Invalid plot id.");
+                return true;
+            }
+            if (action.equalsIgnoreCase("setplot")) {
+                plugin.getMallManager().definePlot(id, player.getLocation().getChunk());
+                sender.sendMessage("Mall plot " + id + " set to current chunk.");
+                return true;
+            }
+            if (action.equalsIgnoreCase("clear")) {
+                plugin.getMallManager().clearPlotOwner(id);
+                sender.sendMessage("Mall plot " + id + " cleared.");
+                return true;
+            }
+        }
+        return true;
+    }
+}

--- a/src/main/java/com/controlbro/claimy/commands/TownCommand.java
+++ b/src/main/java/com/controlbro/claimy/commands/TownCommand.java
@@ -1,0 +1,286 @@
+package com.controlbro.claimy.commands;
+
+import com.controlbro.claimy.ClaimyPlugin;
+import com.controlbro.claimy.model.Town;
+import com.controlbro.claimy.model.TownFlag;
+import com.controlbro.claimy.util.MessageUtil;
+import net.milkbowl.vault.economy.Economy;
+import org.bukkit.Bukkit;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+import java.util.Locale;
+import java.util.Optional;
+
+public class TownCommand implements CommandExecutor {
+    private final ClaimyPlugin plugin;
+
+    public TownCommand(ClaimyPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player player)) {
+            sender.sendMessage("Players only.");
+            return true;
+        }
+        if (args.length == 0) {
+            plugin.getTownGui().openMain(player);
+            return true;
+        }
+        String sub = args[0].toLowerCase(Locale.ROOT);
+        switch (sub) {
+            case "create" -> handleCreate(player, args);
+            case "delete" -> handleDelete(player);
+            case "invite" -> handleInvite(player, args);
+            case "accept" -> handleAccept(player, args);
+            case "kick" -> handleKick(player, args);
+            case "flag" -> handleFlag(player, args);
+            case "border" -> handleBorder(player);
+            case "buy" -> handleBuy(player, args);
+            case "ally" -> handleAlly(player, args);
+            case "unally" -> handleUnally(player, args);
+            default -> plugin.getTownGui().openMain(player);
+        }
+        return true;
+    }
+
+    private void handleCreate(Player player, String[] args) {
+        if (args.length < 2) {
+            player.sendMessage("/town create <name>");
+            return;
+        }
+        if (plugin.getTownManager().getTown(player.getUniqueId()).isPresent()) {
+            player.sendMessage("You are already in a town.");
+            return;
+        }
+        String name = args[1];
+        if (plugin.getTownManager().getTown(name).isPresent()) {
+            player.sendMessage("Town already exists.");
+            return;
+        }
+        Town town = plugin.getTownManager().createTown(name, player.getUniqueId());
+        plugin.getTownManager().claimChunk(town, player.getLocation().getChunk());
+        MessageUtil.send(plugin, player, "town-created", "town", town.getName());
+    }
+
+    private void handleDelete(Player player) {
+        Optional<Town> townOptional = plugin.getTownManager().getTown(player.getUniqueId());
+        if (townOptional.isEmpty()) {
+            MessageUtil.send(plugin, player, "no-town");
+            return;
+        }
+        Town town = townOptional.get();
+        if (!town.getOwner().equals(player.getUniqueId()) && !player.hasPermission("claimy.admin")) {
+            player.sendMessage("Only the owner can delete the town.");
+            return;
+        }
+        plugin.getTownManager().deleteTown(town);
+        MessageUtil.send(plugin, player, "town-deleted");
+    }
+
+    private void handleInvite(Player player, String[] args) {
+        if (args.length < 2) {
+            player.sendMessage("/town invite <player>");
+            return;
+        }
+        Optional<Town> townOptional = plugin.getTownManager().getTown(player.getUniqueId());
+        if (townOptional.isEmpty()) {
+            MessageUtil.send(plugin, player, "no-town");
+            return;
+        }
+        Town town = townOptional.get();
+        if (!town.getOwner().equals(player.getUniqueId())) {
+            player.sendMessage("Only the owner can invite.");
+            return;
+        }
+        Player target = Bukkit.getPlayerExact(args[1]);
+        if (target == null) {
+            player.sendMessage("Player not found.");
+            return;
+        }
+        plugin.getTownManager().invitePlayer(target.getUniqueId(), town);
+        MessageUtil.send(plugin, player, "invite-sent", "player", target.getName());
+        MessageUtil.send(plugin, target, "invite-received", "town", town.getName());
+    }
+
+    private void handleAccept(Player player, String[] args) {
+        String townName = args.length >= 2 ? args[1] : null;
+        Optional<String> invite = plugin.getTownManager().getInvite(player.getUniqueId());
+        if (invite.isEmpty()) {
+            player.sendMessage("You have no invites.");
+            return;
+        }
+        if (townName != null && !invite.get().equalsIgnoreCase(townName)) {
+            player.sendMessage("You do not have an invite to that town.");
+            return;
+        }
+        Optional<Town> townOptional = plugin.getTownManager().getTown(invite.get());
+        if (townOptional.isEmpty()) {
+            player.sendMessage("Town no longer exists.");
+            return;
+        }
+        plugin.getTownManager().addResident(townOptional.get(), player.getUniqueId());
+        plugin.getTownManager().clearInvite(player.getUniqueId());
+        MessageUtil.send(plugin, player, "joined-town", "town", townOptional.get().getName());
+    }
+
+    private void handleKick(Player player, String[] args) {
+        if (args.length < 2) {
+            player.sendMessage("/town kick <player>");
+            return;
+        }
+        Optional<Town> townOptional = plugin.getTownManager().getTown(player.getUniqueId());
+        if (townOptional.isEmpty()) {
+            MessageUtil.send(plugin, player, "no-town");
+            return;
+        }
+        Town town = townOptional.get();
+        if (!town.getOwner().equals(player.getUniqueId())) {
+            player.sendMessage("Only the owner can kick.");
+            return;
+        }
+        Player target = Bukkit.getPlayerExact(args[1]);
+        if (target == null) {
+            player.sendMessage("Player not found.");
+            return;
+        }
+        if (town.getOwner().equals(target.getUniqueId())) {
+            player.sendMessage("You cannot kick the owner.");
+            return;
+        }
+        if (plugin.getTownManager().removeResident(town, target.getUniqueId())) {
+            MessageUtil.send(plugin, player, "kicked", "player", target.getName());
+            target.sendMessage("You were removed from the town.");
+        }
+    }
+
+    private void handleFlag(Player player, String[] args) {
+        if (args.length < 3) {
+            player.sendMessage("/town flag <flag> <true|false>");
+            return;
+        }
+        Optional<Town> townOptional = plugin.getTownManager().getTown(player.getUniqueId());
+        if (townOptional.isEmpty()) {
+            MessageUtil.send(plugin, player, "no-town");
+            return;
+        }
+        Town town = townOptional.get();
+        if (!town.getOwner().equals(player.getUniqueId())) {
+            player.sendMessage("Only the owner can change flags.");
+            return;
+        }
+        TownFlag flag;
+        try {
+            flag = TownFlag.valueOf(args[1].toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException ex) {
+            player.sendMessage("Unknown flag.");
+            return;
+        }
+        boolean value = Boolean.parseBoolean(args[2]);
+        town.setFlag(flag, value);
+        plugin.getTownManager().save();
+        MessageUtil.send(plugin, player, "town-flag-updated", "flag", flag.name(), "value", String.valueOf(value));
+    }
+
+    private void handleBorder(Player player) {
+        Optional<Town> townOptional = plugin.getTownManager().getTown(player.getUniqueId());
+        if (townOptional.isEmpty()) {
+            MessageUtil.send(plugin, player, "no-town");
+            return;
+        }
+        plugin.getTownGui().showBorder(player, townOptional.get());
+    }
+
+    private void handleBuy(Player player, String[] args) {
+        if (args.length < 2) {
+            player.sendMessage("/town buy <amount>");
+            return;
+        }
+        Optional<Town> townOptional = plugin.getTownManager().getTown(player.getUniqueId());
+        if (townOptional.isEmpty()) {
+            MessageUtil.send(plugin, player, "no-town");
+            return;
+        }
+        int amount;
+        try {
+            amount = Integer.parseInt(args[1]);
+        } catch (NumberFormatException ex) {
+            player.sendMessage("Invalid amount.");
+            return;
+        }
+        if (amount <= 0) {
+            player.sendMessage("Amount must be positive.");
+            return;
+        }
+        Economy economy = plugin.getEconomy();
+        double cost = amount * plugin.getConfig().getDouble("settings.chunk-cost");
+        if (economy == null) {
+            player.sendMessage("Economy not available.");
+            return;
+        }
+        if (!economy.has(player, cost)) {
+            MessageUtil.send(plugin, player, "not-enough-money", "cost", String.valueOf(cost), "count", String.valueOf(amount));
+            return;
+        }
+        economy.withdrawPlayer(player, cost);
+        townOptional.get().addChunkLimit(amount);
+        plugin.getTownManager().save();
+        MessageUtil.send(plugin, player, "chunk-bought", "count", String.valueOf(amount), "cost", String.valueOf(cost));
+    }
+
+    private void handleAlly(Player player, String[] args) {
+        if (args.length < 2) {
+            player.sendMessage("/town ally <town>");
+            return;
+        }
+        Optional<Town> townOptional = plugin.getTownManager().getTown(player.getUniqueId());
+        if (townOptional.isEmpty()) {
+            MessageUtil.send(plugin, player, "no-town");
+            return;
+        }
+        Town town = townOptional.get();
+        if (!town.getOwner().equals(player.getUniqueId())) {
+            player.sendMessage("Only the owner can ally.");
+            return;
+        }
+        Optional<Town> allyOptional = plugin.getTownManager().getTown(args[1]);
+        if (allyOptional.isEmpty()) {
+            player.sendMessage("Town not found.");
+            return;
+        }
+        Town ally = allyOptional.get();
+        plugin.getTownManager().addAlly(town, ally);
+        plugin.getTownManager().addAlly(ally, town);
+        player.sendMessage("Town allied with " + ally.getName());
+    }
+
+    private void handleUnally(Player player, String[] args) {
+        if (args.length < 2) {
+            player.sendMessage("/town unally <town>");
+            return;
+        }
+        Optional<Town> townOptional = plugin.getTownManager().getTown(player.getUniqueId());
+        if (townOptional.isEmpty()) {
+            MessageUtil.send(plugin, player, "no-town");
+            return;
+        }
+        Town town = townOptional.get();
+        if (!town.getOwner().equals(player.getUniqueId())) {
+            player.sendMessage("Only the owner can unally.");
+            return;
+        }
+        Optional<Town> allyOptional = plugin.getTownManager().getTown(args[1]);
+        if (allyOptional.isEmpty()) {
+            player.sendMessage("Town not found.");
+            return;
+        }
+        Town ally = allyOptional.get();
+        plugin.getTownManager().removeAlly(town, ally);
+        plugin.getTownManager().removeAlly(ally, town);
+        player.sendMessage("Town unallied with " + ally.getName());
+    }
+}

--- a/src/main/java/com/controlbro/claimy/gui/TownBorderRenderer.java
+++ b/src/main/java/com/controlbro/claimy/gui/TownBorderRenderer.java
@@ -1,0 +1,45 @@
+package com.controlbro.claimy.gui;
+
+import com.controlbro.claimy.model.ChunkKey;
+import com.controlbro.claimy.model.Town;
+import org.bukkit.Location;
+import org.bukkit.Particle;
+import org.bukkit.World;
+import org.bukkit.entity.Player;
+
+public class TownBorderRenderer {
+    private TownBorderRenderer() {
+    }
+
+    public static void render(Player player, Town town) {
+        World world = player.getWorld();
+        int playerChunkX = player.getLocation().getChunk().getX();
+        int playerChunkZ = player.getLocation().getChunk().getZ();
+        for (ChunkKey key : town.getChunks()) {
+            if (!key.getWorld().equals(world.getName())) {
+                continue;
+            }
+            if (Math.abs(key.getX() - playerChunkX) > 4 || Math.abs(key.getZ() - playerChunkZ) > 4) {
+                continue;
+            }
+            int minX = key.getX() << 4;
+            int minZ = key.getZ() << 4;
+            int maxX = minX + 15;
+            int maxZ = minZ + 15;
+            for (int x = minX; x <= maxX; x++) {
+                spawn(world, x, minZ, player);
+                spawn(world, x, maxZ, player);
+            }
+            for (int z = minZ; z <= maxZ; z++) {
+                spawn(world, minX, z, player);
+                spawn(world, maxX, z, player);
+            }
+        }
+    }
+
+    private static void spawn(World world, int x, int z, Player player) {
+        int y = world.getHighestBlockYAt(x, z) + 1;
+        Location location = new Location(world, x + 0.5, y, z + 0.5);
+        player.spawnParticle(Particle.REDSTONE, location, 1, new Particle.DustOptions(org.bukkit.Color.LIME, 1));
+    }
+}

--- a/src/main/java/com/controlbro/claimy/gui/TownGui.java
+++ b/src/main/java/com/controlbro/claimy/gui/TownGui.java
@@ -1,0 +1,152 @@
+package com.controlbro.claimy.gui;
+
+import com.controlbro.claimy.ClaimyPlugin;
+import com.controlbro.claimy.model.Town;
+import com.controlbro.claimy.model.TownFlag;
+import com.controlbro.claimy.util.MessageUtil;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+
+public class TownGui implements Listener {
+    private final ClaimyPlugin plugin;
+    private YamlConfiguration guiConfig;
+
+    public TownGui(ClaimyPlugin plugin) {
+        this.plugin = plugin;
+        reload();
+    }
+
+    public void reload() {
+        File file = new File(plugin.getDataFolder(), "gui.yml");
+        guiConfig = YamlConfiguration.loadConfiguration(file);
+    }
+
+    public void openMain(Player player) {
+        String title = MessageUtil.color(guiConfig.getString("menu.title", "Town"));
+        int size = guiConfig.getInt("menu.size", 27);
+        Inventory inventory = Bukkit.createInventory(player, size, title);
+        ConfigurationSection items = guiConfig.getConfigurationSection("menu.items");
+        if (items != null) {
+            for (String key : items.getKeys(false)) {
+                ConfigurationSection itemSection = items.getConfigurationSection(key);
+                if (itemSection == null) {
+                    continue;
+                }
+                int slot = itemSection.getInt("slot");
+                Material material = Material.matchMaterial(itemSection.getString("material", "STONE"));
+                ItemStack stack = new ItemStack(material == null ? Material.STONE : material);
+                ItemMeta meta = stack.getItemMeta();
+                meta.setDisplayName(MessageUtil.color(itemSection.getString("name", key)));
+                List<String> lore = new ArrayList<>();
+                for (String line : itemSection.getStringList("lore")) {
+                    lore.add(MessageUtil.color(line));
+                }
+                meta.setLore(lore);
+                stack.setItemMeta(meta);
+                inventory.setItem(slot, stack);
+            }
+        }
+        player.openInventory(inventory);
+    }
+
+    public void openFlags(Player player, Town town) {
+        String title = MessageUtil.color(guiConfig.getString("flags.title", "Flags"));
+        int size = guiConfig.getInt("flags.size", 27);
+        Inventory inventory = Bukkit.createInventory(player, size, title);
+        int slot = 10;
+        for (TownFlag flag : TownFlag.values()) {
+            boolean enabled = town.isFlagEnabled(flag);
+            ItemStack stack = new ItemStack(enabled ? Material.LIME_DYE : Material.GRAY_DYE);
+            ItemMeta meta = stack.getItemMeta();
+            meta.setDisplayName(MessageUtil.color("&e" + flag.name()));
+            List<String> lore = new ArrayList<>();
+            lore.add(MessageUtil.color("&7Current: " + enabled));
+            lore.add(MessageUtil.color("&7Click to toggle"));
+            meta.setLore(lore);
+            stack.setItemMeta(meta);
+            inventory.setItem(slot, stack);
+            slot++;
+        }
+        player.openInventory(inventory);
+    }
+
+    public void showBorder(Player player, Town town) {
+        if (!plugin.getConfig().getBoolean("settings.show-border-particles")) {
+            return;
+        }
+        plugin.getServer().getScheduler().runTask(plugin, () -> TownBorderRenderer.render(player, town));
+    }
+
+    @EventHandler
+    public void onInventoryClick(InventoryClickEvent event) {
+        if (!(event.getWhoClicked() instanceof Player player)) {
+            return;
+        }
+        String title = event.getView().getTitle();
+        if (title.equals(MessageUtil.color(guiConfig.getString("menu.title", "Town")))) {
+            event.setCancelled(true);
+            if (event.getCurrentItem() == null) {
+                return;
+            }
+            String display = event.getCurrentItem().getItemMeta() != null
+                    ? event.getCurrentItem().getItemMeta().getDisplayName()
+                    : "";
+            if (display.contains("Create")) {
+                player.sendMessage("Use /town create <name>");
+            } else if (display.contains("Delete")) {
+                player.sendMessage("Use /town delete");
+            } else if (display.contains("Invite")) {
+                player.sendMessage("Use /town invite <player>");
+            } else if (display.contains("Kick")) {
+                player.sendMessage("Use /town kick <player>");
+            } else if (display.contains("Border")) {
+                Optional<Town> townOptional = plugin.getTownManager().getTown(player.getUniqueId());
+                townOptional.ifPresent(town -> showBorder(player, town));
+            } else if (display.contains("Flags")) {
+                Optional<Town> townOptional = plugin.getTownManager().getTown(player.getUniqueId());
+                townOptional.ifPresent(town -> openFlags(player, town));
+            } else if (display.contains("Buy")) {
+                player.sendMessage("Use /town buy <amount>");
+            }
+        }
+        if (title.equals(MessageUtil.color(guiConfig.getString("flags.title", "Flags")))) {
+            event.setCancelled(true);
+            if (event.getCurrentItem() == null) {
+                return;
+            }
+            Optional<Town> townOptional = plugin.getTownManager().getTown(player.getUniqueId());
+            if (townOptional.isEmpty()) {
+                return;
+            }
+            Town town = townOptional.get();
+            String displayName = event.getCurrentItem().getItemMeta() != null
+                    ? event.getCurrentItem().getItemMeta().getDisplayName()
+                    : "";
+            String flagName = ChatColor.stripColor(displayName);
+            try {
+                TownFlag flag = TownFlag.valueOf(flagName.toUpperCase(Locale.ROOT));
+                town.setFlag(flag, !town.isFlagEnabled(flag));
+                plugin.getTownManager().save();
+                openFlags(player, town);
+            } catch (IllegalArgumentException ex) {
+                // ignore
+            }
+        }
+    }
+}

--- a/src/main/java/com/controlbro/claimy/listeners/ProtectionListener.java
+++ b/src/main/java/com/controlbro/claimy/listeners/ProtectionListener.java
@@ -1,0 +1,436 @@
+package com.controlbro.claimy.listeners;
+
+import com.controlbro.claimy.ClaimyPlugin;
+import com.controlbro.claimy.model.Town;
+import com.controlbro.claimy.model.TownFlag;
+import com.controlbro.claimy.util.MessageUtil;
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Animals;
+import org.bukkit.entity.Creeper;
+import org.bukkit.entity.Enderman;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.FallingBlock;
+import org.bukkit.entity.Player;
+import org.bukkit.entity.Tameable;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.event.block.BlockFromToEvent;
+import org.bukkit.event.block.BlockPistonExtendEvent;
+import org.bukkit.event.block.BlockPistonRetractEvent;
+import org.bukkit.event.block.BlockPlaceEvent;
+import org.bukkit.event.entity.EntityChangeBlockEvent;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.bukkit.event.entity.EntityExplodeEvent;
+import org.bukkit.event.world.PortalCreateEvent;
+import org.bukkit.event.hanging.HangingBreakByEntityEvent;
+import org.bukkit.event.hanging.HangingPlaceEvent;
+import org.bukkit.event.player.PlayerBucketEmptyEvent;
+import org.bukkit.event.player.PlayerBucketFillEvent;
+import org.bukkit.event.player.PlayerInteractEntityEvent;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.*;
+
+public class ProtectionListener implements Listener {
+    private final ClaimyPlugin plugin;
+    private final Map<UUID, Long> warningCooldowns = new HashMap<>();
+
+    public ProtectionListener(ClaimyPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @EventHandler
+    public void onBlockBreak(BlockBreakEvent event) {
+        if (canBuild(event.getPlayer(), event.getBlock())) {
+            return;
+        }
+        event.setCancelled(true);
+        MessageUtil.send(plugin, event.getPlayer(), "claim-denied");
+    }
+
+    @EventHandler
+    public void onBlockPlace(BlockPlaceEvent event) {
+        if (canBuild(event.getPlayer(), event.getBlock())) {
+            warnIfOutside(event.getPlayer(), event.getBlock());
+            return;
+        }
+        event.setCancelled(true);
+        MessageUtil.send(plugin, event.getPlayer(), "claim-denied");
+    }
+
+    @EventHandler
+    public void onBucketFill(PlayerBucketFillEvent event) {
+        if (!canBuild(event.getPlayer(), event.getBlockClicked())) {
+            event.setCancelled(true);
+            MessageUtil.send(plugin, event.getPlayer(), "claim-denied");
+        }
+    }
+
+    @EventHandler
+    public void onBucketEmpty(PlayerBucketEmptyEvent event) {
+        if (!canBuild(event.getPlayer(), event.getBlockClicked())) {
+            event.setCancelled(true);
+            MessageUtil.send(plugin, event.getPlayer(), "claim-denied");
+        }
+    }
+
+    @EventHandler
+    public void onInteract(PlayerInteractEvent event) {
+        if (event.getHand() != EquipmentSlot.HAND) {
+            return;
+        }
+        Player player = event.getPlayer();
+        ItemStack item = event.getItem();
+        if (item != null && item.getType() == Material.GOLDEN_SHOVEL && event.getClickedBlock() != null) {
+            handleClaimTool(player, event.getClickedBlock());
+            event.setCancelled(true);
+            return;
+        }
+        if (event.getClickedBlock() == null) {
+            return;
+        }
+        Block block = event.getClickedBlock();
+        Material type = block.getType();
+        if (isContainer(type)) {
+            if (!canAccessContainer(player, block)) {
+                event.setCancelled(true);
+                MessageUtil.send(plugin, player, "claim-denied");
+            }
+            return;
+        }
+        if (type == Material.BEDROCK) {
+            return;
+        }
+        if (isBed(type) || isRedstoneControl(type)) {
+            if (!canUseDoorsVillagers(player, block)) {
+                event.setCancelled(true);
+                MessageUtil.send(plugin, player, "claim-denied");
+            }
+        }
+        if (isDoor(type)) {
+            if (!canUseDoor(player, block)) {
+                event.setCancelled(true);
+                MessageUtil.send(plugin, player, "claim-denied");
+            }
+        }
+    }
+
+    @EventHandler
+    public void onInteractEntity(PlayerInteractEntityEvent event) {
+        Player player = event.getPlayer();
+        Entity entity = event.getRightClicked();
+        if (entity.getType() == EntityType.VILLAGER) {
+            if (!canUseVillagers(player, entity)) {
+                event.setCancelled(true);
+            }
+        }
+        if (entity instanceof Animals) {
+            if (!canUseDoorsVillagers(player, entity.getLocation().getBlock())) {
+                event.setCancelled(true);
+            }
+        }
+    }
+
+    @EventHandler
+    public void onEntityDamage(EntityDamageByEntityEvent event) {
+        Entity entity = event.getEntity();
+        if (entity instanceof Tameable tameable && tameable.getOwner() != null) {
+            if (plugin.getConfig().getBoolean("settings.protect-pets.enabled")
+                    && plugin.getConfig().getStringList("settings.protect-pets.worlds").contains(entity.getWorld().getName())) {
+                if (event.getDamager() instanceof Player player) {
+                    if (!player.getUniqueId().equals(tameable.getOwner().getUniqueId()) && !player.hasPermission("claimy.admin")) {
+                        event.setCancelled(true);
+                        return;
+                    }
+                } else {
+                    event.setCancelled(true);
+                    return;
+                }
+            }
+        }
+        if (entity instanceof Animals || entity instanceof Creeper) {
+            if (event.getDamager() instanceof Player player) {
+                if (!canUseDoorsVillagers(player, entity.getLocation().getBlock())) {
+                    event.setCancelled(true);
+                }
+            }
+        }
+        if (event.getDamager() instanceof Creeper) {
+            if (plugin.getTownManager().getTownAt(entity.getLocation()).isPresent()) {
+                event.setCancelled(true);
+            }
+        }
+    }
+
+    @EventHandler
+    public void onEntityChangeBlock(EntityChangeBlockEvent event) {
+        if (event.getEntity() instanceof Enderman) {
+            event.setCancelled(true);
+            return;
+        }
+        if (event.getEntity() instanceof FallingBlock) {
+            if (plugin.getTownManager().getTownAt(event.getBlock().getLocation()).isPresent()
+                    || plugin.getMallManager().isInMall(event.getBlock().getLocation())) {
+                event.setCancelled(true);
+                return;
+            }
+        }
+        if (event.getBlock().getType() == Material.FARMLAND) {
+            event.setCancelled(true);
+        }
+    }
+
+    @EventHandler
+    public void onExplosion(EntityExplodeEvent event) {
+        int seaLevel = event.getLocation().getWorld().getSeaLevel();
+        if (plugin.getConfig().getBoolean("settings.disable-explosions-above-sea-level")
+                && event.getLocation().getY() > seaLevel) {
+            event.setCancelled(true);
+            return;
+        }
+        event.blockList().clear();
+    }
+
+    @EventHandler
+    public void onPortalCreate(PortalCreateEvent event) {
+        if (!(event.getEntity() instanceof Player player)) {
+            return;
+        }
+        for (var blockState : event.getBlocks()) {
+            Block block = blockState.getBlock();
+            if (!canBuild(player, block)) {
+                event.setCancelled(true);
+                return;
+            }
+        }
+    }
+
+    @EventHandler
+    public void onBlockFromTo(BlockFromToEvent event) {
+        if (plugin.getTownManager().getTownAt(event.getToBlock().getLocation()).isPresent()
+                && plugin.getTownManager().getTownAt(event.getBlock().getLocation()).isEmpty()) {
+            event.setCancelled(true);
+        }
+    }
+
+    @EventHandler
+    public void onPistonExtend(BlockPistonExtendEvent event) {
+        for (Block block : event.getBlocks()) {
+            if (isMovingAcrossClaims(block, block.getRelative(event.getDirection()))) {
+                event.setCancelled(true);
+                return;
+            }
+        }
+    }
+
+    @EventHandler
+    public void onPistonRetract(BlockPistonRetractEvent event) {
+        for (Block block : event.getBlocks()) {
+            if (isMovingAcrossClaims(block, block.getRelative(event.getDirection()))) {
+                event.setCancelled(true);
+                return;
+            }
+        }
+    }
+
+    @EventHandler
+    public void onHangingPlace(HangingPlaceEvent event) {
+        if (!canBuild(event.getPlayer(), event.getEntity().getLocation().getBlock())) {
+            event.setCancelled(true);
+        }
+    }
+
+    @EventHandler
+    public void onHangingBreak(HangingBreakByEntityEvent event) {
+        if (event.getRemover() instanceof Player player) {
+            if (!canBuild(player, event.getEntity().getLocation().getBlock())) {
+                event.setCancelled(true);
+            }
+        }
+    }
+
+    private void handleClaimTool(Player player, Block block) {
+        if (player.hasPermission("claimy.admin")) {
+            return;
+        }
+        Optional<Town> townOptional = plugin.getTownManager().getTown(player.getUniqueId());
+        if (townOptional.isEmpty()) {
+            MessageUtil.send(plugin, player, "no-town");
+            return;
+        }
+        Town town = townOptional.get();
+        if (plugin.getMallManager().isInMall(block.getLocation())) {
+            player.sendMessage("You cannot claim a town chunk inside the mall.");
+            return;
+        }
+        if (plugin.getTownManager().isChunkClaimed(block.getChunk())) {
+            player.sendMessage("Chunk already claimed.");
+            return;
+        }
+        if (plugin.getTownManager().claimChunk(town, block.getChunk())) {
+            player.sendMessage("Chunk claimed.");
+        } else {
+            player.sendMessage("You have reached your chunk limit.");
+        }
+    }
+
+    private boolean canBuild(Player player, Block block) {
+        if (player.hasPermission("claimy.admin")) {
+            return true;
+        }
+        if (plugin.getMallManager().isInMall(block.getLocation())) {
+            return plugin.getMallManager().isMallOwner(block.getLocation(), player.getUniqueId());
+        }
+        Optional<Town> townOptional = plugin.getTownManager().getTownAt(block.getLocation());
+        if (townOptional.isEmpty()) {
+            return true;
+        }
+        Town town = townOptional.get();
+        if (town.isResident(player.getUniqueId())) {
+            return true;
+        }
+        Optional<Town> playerTown = plugin.getTownManager().getTown(player.getUniqueId());
+        if (playerTown.isPresent()) {
+            Town ownTown = playerTown.get();
+            if (plugin.getTownManager().isTownAlly(town, ownTown) && town.isFlagEnabled(TownFlag.ALLOW_ALLY_BUILD)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean canAccessContainer(Player player, Block block) {
+        if (player.hasPermission("claimy.admin")) {
+            return true;
+        }
+        if (plugin.getMallManager().isInMall(block.getLocation())) {
+            return plugin.getMallManager().isMallOwner(block.getLocation(), player.getUniqueId());
+        }
+        Optional<Town> townOptional = plugin.getTownManager().getTownAt(block.getLocation());
+        if (townOptional.isEmpty()) {
+            return true;
+        }
+        Town town = townOptional.get();
+        return town.isResident(player.getUniqueId());
+    }
+
+    private boolean canUseDoorsVillagers(Player player, Block block) {
+        if (player.hasPermission("claimy.admin")) {
+            return true;
+        }
+        if (plugin.getMallManager().isInMall(block.getLocation())) {
+            return plugin.getMallManager().isMallOwner(block.getLocation(), player.getUniqueId());
+        }
+        Optional<Town> townOptional = plugin.getTownManager().getTownAt(block.getLocation());
+        if (townOptional.isEmpty()) {
+            return true;
+        }
+        Town town = townOptional.get();
+        if (town.isResident(player.getUniqueId())) {
+            return true;
+        }
+        Optional<Town> playerTown = plugin.getTownManager().getTown(player.getUniqueId());
+        if (playerTown.isPresent()) {
+            Town ownTown = playerTown.get();
+            if (plugin.getTownManager().isTownAlly(town, ownTown) && town.isFlagEnabled(TownFlag.ALLOW_ALLY_DOORS)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean canUseDoor(Player player, Block block) {
+        if (!plugin.getConfig().getBoolean("settings.lock-doors-by-default")) {
+            return true;
+        }
+        return canUseDoorsVillagers(player, block);
+    }
+
+    private boolean canUseVillagers(Player player, Entity entity) {
+        if (player.hasPermission("claimy.admin")) {
+            return true;
+        }
+        Optional<Town> townOptional = plugin.getTownManager().getTownAt(entity.getLocation());
+        if (townOptional.isEmpty()) {
+            return true;
+        }
+        Town town = townOptional.get();
+        if (town.isResident(player.getUniqueId())) {
+            return true;
+        }
+        Optional<Town> playerTown = plugin.getTownManager().getTown(player.getUniqueId());
+        if (playerTown.isPresent()) {
+            Town ownTown = playerTown.get();
+            if (plugin.getTownManager().isTownAlly(town, ownTown) && town.isFlagEnabled(TownFlag.ALLOW_ALLY_VILLAGERS)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean isContainer(Material type) {
+        return type == Material.CHEST
+                || type == Material.TRAPPED_CHEST
+                || type == Material.BARREL
+                || type == Material.SHULKER_BOX
+                || type.name().endsWith("SHULKER_BOX")
+                || type == Material.FURNACE
+                || type == Material.BLAST_FURNACE
+                || type == Material.SMOKER
+                || type == Material.HOPPER
+                || type == Material.DROPPER
+                || type == Material.DISPENSER
+                || type == Material.BREWING_STAND
+                || type == Material.CRAFTER
+                || type == Material.ENDER_CHEST;
+    }
+
+    private boolean isBed(Material type) {
+        return type.name().endsWith("_BED");
+    }
+
+    private boolean isDoor(Material type) {
+        return type.name().endsWith("_DOOR") || type == Material.IRON_DOOR;
+    }
+
+    private boolean isRedstoneControl(Material type) {
+        return type == Material.LEVER
+                || type.name().endsWith("_BUTTON")
+                || type == Material.REPEATER
+                || type == Material.COMPARATOR;
+    }
+
+    private boolean isMovingAcrossClaims(Block source, Block destination) {
+        Optional<Town> sourceTown = plugin.getTownManager().getTownAt(source.getLocation());
+        Optional<Town> destTown = plugin.getTownManager().getTownAt(destination.getLocation());
+        if (sourceTown.isPresent() && destTown.isPresent()) {
+            return !sourceTown.get().getName().equalsIgnoreCase(destTown.get().getName());
+        }
+        return sourceTown.isPresent() || destTown.isPresent();
+    }
+
+    private void warnIfOutside(Player player, Block block) {
+        if (plugin.getTownManager().getTown(player.getUniqueId()).isEmpty()) {
+            return;
+        }
+        Optional<Town> townOptional = plugin.getTownManager().getTownAt(block.getLocation());
+        if (townOptional.isPresent()) {
+            return;
+        }
+        long now = System.currentTimeMillis();
+        long cooldown = plugin.getConfig().getLong("settings.warning-cooldown-seconds") * 1000L;
+        long last = warningCooldowns.getOrDefault(player.getUniqueId(), 0L);
+        if (now - last < cooldown) {
+            return;
+        }
+        warningCooldowns.put(player.getUniqueId(), now);
+        MessageUtil.send(plugin, player, "claim-warning");
+        plugin.getTownManager().getTown(player.getUniqueId())
+                .ifPresent(town -> plugin.getTownGui().showBorder(player, town));
+    }
+}

--- a/src/main/java/com/controlbro/claimy/managers/MallManager.java
+++ b/src/main/java/com/controlbro/claimy/managers/MallManager.java
@@ -1,0 +1,127 @@
+package com.controlbro.claimy.managers;
+
+import com.controlbro.claimy.ClaimyPlugin;
+import com.controlbro.claimy.model.ChunkKey;
+import org.bukkit.Chunk;
+import org.bukkit.Location;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.YamlConfiguration;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+public class MallManager {
+    private final ClaimyPlugin plugin;
+    private final File file;
+    private YamlConfiguration config;
+    private final Map<Integer, ChunkKey> plots = new HashMap<>();
+    private final Map<Integer, UUID> plotOwners = new HashMap<>();
+
+    public MallManager(ClaimyPlugin plugin) {
+        this.plugin = plugin;
+        this.file = new File(plugin.getDataFolder(), "mall.yml");
+        load();
+    }
+
+    public void load() {
+        if (!file.exists()) {
+            try {
+                file.getParentFile().mkdirs();
+                file.createNewFile();
+            } catch (IOException e) {
+                plugin.getLogger().warning("Failed to create mall.yml: " + e.getMessage());
+            }
+        }
+        config = YamlConfiguration.loadConfiguration(file);
+        plots.clear();
+        plotOwners.clear();
+        ConfigurationSection plotsSection = config.getConfigurationSection("plots");
+        if (plotsSection == null) {
+            return;
+        }
+        for (String key : plotsSection.getKeys(false)) {
+            int id = Integer.parseInt(key);
+            ConfigurationSection section = plotsSection.getConfigurationSection(key);
+            if (section == null) {
+                continue;
+            }
+            ChunkKey chunkKey = ChunkKey.fromString(section.getString("chunk"));
+            plots.put(id, chunkKey);
+            String owner = section.getString("owner");
+            if (owner != null && !owner.isBlank()) {
+                plotOwners.put(id, UUID.fromString(owner));
+            }
+        }
+    }
+
+    public void save() {
+        config = new YamlConfiguration();
+        ConfigurationSection plotsSection = config.createSection("plots");
+        for (Map.Entry<Integer, ChunkKey> entry : plots.entrySet()) {
+            ConfigurationSection section = plotsSection.createSection(String.valueOf(entry.getKey()));
+            section.set("chunk", entry.getValue().asString());
+            UUID owner = plotOwners.get(entry.getKey());
+            if (owner != null) {
+                section.set("owner", owner.toString());
+            }
+        }
+        try {
+            config.save(file);
+        } catch (IOException e) {
+            plugin.getLogger().warning("Failed to save mall.yml: " + e.getMessage());
+        }
+    }
+
+    public void definePlot(int id, Chunk chunk) {
+        plots.put(id, new ChunkKey(chunk.getWorld().getName(), chunk.getX(), chunk.getZ()));
+        save();
+    }
+
+    public Optional<ChunkKey> getPlotChunk(int id) {
+        return Optional.ofNullable(plots.get(id));
+    }
+
+    public Optional<UUID> getPlotOwner(int id) {
+        return Optional.ofNullable(plotOwners.get(id));
+    }
+
+    public boolean claimPlot(int id, UUID playerId) {
+        if (!plots.containsKey(id)) {
+            return false;
+        }
+        if (plotOwners.containsKey(id)) {
+            return false;
+        }
+        plotOwners.put(id, playerId);
+        save();
+        return true;
+    }
+
+    public Optional<Integer> getPlotAt(Location location) {
+        ChunkKey key = new ChunkKey(location.getWorld().getName(), location.getChunk().getX(), location.getChunk().getZ());
+        for (Map.Entry<Integer, ChunkKey> entry : plots.entrySet()) {
+            if (entry.getValue().equals(key)) {
+                return Optional.of(entry.getKey());
+            }
+        }
+        return Optional.empty();
+    }
+
+    public boolean isInMall(Location location) {
+        return getPlotAt(location).isPresent();
+    }
+
+    public boolean isMallOwner(Location location, UUID playerId) {
+        Optional<Integer> plotId = getPlotAt(location);
+        return plotId.isPresent() && playerId.equals(plotOwners.get(plotId.get()));
+    }
+
+    public void clearPlotOwner(int id) {
+        plotOwners.remove(id);
+        save();
+    }
+}

--- a/src/main/java/com/controlbro/claimy/managers/TownManager.java
+++ b/src/main/java/com/controlbro/claimy/managers/TownManager.java
@@ -1,0 +1,214 @@
+package com.controlbro.claimy.managers;
+
+import com.controlbro.claimy.ClaimyPlugin;
+import com.controlbro.claimy.model.ChunkKey;
+import com.controlbro.claimy.model.Town;
+import com.controlbro.claimy.model.TownFlag;
+import org.bukkit.Bukkit;
+import org.bukkit.Chunk;
+import org.bukkit.Location;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.YamlConfiguration;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.*;
+
+public class TownManager {
+    private final ClaimyPlugin plugin;
+    private final Map<String, Town> towns = new HashMap<>();
+    private final Map<UUID, String> playerTown = new HashMap<>();
+    private final Map<UUID, String> invites = new HashMap<>();
+    private final File file;
+    private YamlConfiguration config;
+
+    public TownManager(ClaimyPlugin plugin) {
+        this.plugin = plugin;
+        this.file = new File(plugin.getDataFolder(), "towns.yml");
+        load();
+    }
+
+    public void load() {
+        if (!file.exists()) {
+            try {
+                file.getParentFile().mkdirs();
+                file.createNewFile();
+            } catch (IOException e) {
+                plugin.getLogger().warning("Failed to create towns.yml: " + e.getMessage());
+            }
+        }
+        config = YamlConfiguration.loadConfiguration(file);
+        towns.clear();
+        playerTown.clear();
+        ConfigurationSection townsSection = config.getConfigurationSection("towns");
+        if (townsSection == null) {
+            return;
+        }
+        for (String name : townsSection.getKeys(false)) {
+            ConfigurationSection section = townsSection.getConfigurationSection(name);
+            if (section == null) {
+                continue;
+            }
+            UUID owner = UUID.fromString(section.getString("owner"));
+            int limit = section.getInt("chunk-limit", plugin.getConfig().getInt("settings.starting-chunk-allowance"));
+            Town town = new Town(name, owner, limit);
+            town.getResidents().clear();
+            for (String resident : section.getStringList("residents")) {
+                town.getResidents().add(UUID.fromString(resident));
+            }
+            town.getAllies().addAll(section.getStringList("allies"));
+            for (String chunkString : section.getStringList("chunks")) {
+                town.getChunks().add(ChunkKey.fromString(chunkString));
+            }
+            ConfigurationSection flagSection = section.getConfigurationSection("flags");
+            if (flagSection != null) {
+                for (TownFlag flag : TownFlag.values()) {
+                    town.setFlag(flag, flagSection.getBoolean(flag.name(), true));
+                }
+            }
+            towns.put(name.toLowerCase(Locale.ROOT), town);
+            for (UUID resident : town.getResidents()) {
+                playerTown.put(resident, name.toLowerCase(Locale.ROOT));
+            }
+        }
+    }
+
+    public void save() {
+        config = new YamlConfiguration();
+        ConfigurationSection townsSection = config.createSection("towns");
+        for (Town town : towns.values()) {
+            ConfigurationSection section = townsSection.createSection(town.getName());
+            section.set("owner", town.getOwner().toString());
+            section.set("chunk-limit", town.getChunkLimit());
+            List<String> residents = new ArrayList<>();
+            for (UUID uuid : town.getResidents()) {
+                residents.add(uuid.toString());
+            }
+            section.set("residents", residents);
+            section.set("allies", new ArrayList<>(town.getAllies()));
+            List<String> chunkStrings = new ArrayList<>();
+            for (ChunkKey key : town.getChunks()) {
+                chunkStrings.add(key.asString());
+            }
+            section.set("chunks", chunkStrings);
+            ConfigurationSection flags = section.createSection("flags");
+            for (TownFlag flag : TownFlag.values()) {
+                flags.set(flag.name(), town.isFlagEnabled(flag));
+            }
+        }
+        try {
+            config.save(file);
+        } catch (IOException e) {
+            plugin.getLogger().warning("Failed to save towns.yml: " + e.getMessage());
+        }
+    }
+
+    public Optional<Town> getTown(String name) {
+        if (name == null) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(towns.get(name.toLowerCase(Locale.ROOT)));
+    }
+
+    public Optional<Town> getTown(UUID playerId) {
+        String townName = playerTown.get(playerId);
+        return getTown(townName);
+    }
+
+    public Town createTown(String name, UUID owner) {
+        Town town = new Town(name, owner, plugin.getConfig().getInt("settings.starting-chunk-allowance"));
+        towns.put(name.toLowerCase(Locale.ROOT), town);
+        playerTown.put(owner, name.toLowerCase(Locale.ROOT));
+        save();
+        return town;
+    }
+
+    public void deleteTown(Town town) {
+        towns.remove(town.getName().toLowerCase(Locale.ROOT));
+        for (UUID resident : town.getResidents()) {
+            playerTown.remove(resident);
+        }
+        save();
+    }
+
+    public boolean addResident(Town town, UUID playerId) {
+        if (town.getResidents().add(playerId)) {
+            playerTown.put(playerId, town.getName().toLowerCase(Locale.ROOT));
+            save();
+            return true;
+        }
+        return false;
+    }
+
+    public boolean removeResident(Town town, UUID playerId) {
+        if (town.getResidents().remove(playerId)) {
+            playerTown.remove(playerId);
+            save();
+            return true;
+        }
+        return false;
+    }
+
+    public void invitePlayer(UUID playerId, Town town) {
+        invites.put(playerId, town.getName().toLowerCase(Locale.ROOT));
+    }
+
+    public Optional<String> getInvite(UUID playerId) {
+        return Optional.ofNullable(invites.get(playerId));
+    }
+
+    public void clearInvite(UUID playerId) {
+        invites.remove(playerId);
+    }
+
+    public Optional<Town> getTownAt(Location location) {
+        ChunkKey key = new ChunkKey(location.getWorld().getName(), location.getChunk().getX(), location.getChunk().getZ());
+        for (Town town : towns.values()) {
+            if (town.getChunks().contains(key)) {
+                return Optional.of(town);
+            }
+        }
+        return Optional.empty();
+    }
+
+    public boolean claimChunk(Town town, Chunk chunk) {
+        if (town.getChunks().size() >= town.getChunkLimit()) {
+            return false;
+        }
+        ChunkKey key = new ChunkKey(chunk.getWorld().getName(), chunk.getX(), chunk.getZ());
+        boolean added = town.getChunks().add(key);
+        if (added) {
+            save();
+        }
+        return added;
+    }
+
+    public boolean isChunkClaimed(Chunk chunk) {
+        ChunkKey key = new ChunkKey(chunk.getWorld().getName(), chunk.getX(), chunk.getZ());
+        for (Town town : towns.values()) {
+            if (town.getChunks().contains(key)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public boolean isTownAlly(Town town, Town other) {
+        return town.getAllies().contains(other.getName());
+    }
+
+    public void addAlly(Town town, Town ally) {
+        town.getAllies().add(ally.getName());
+        save();
+    }
+
+    public void removeAlly(Town town, Town ally) {
+        town.getAllies().remove(ally.getName());
+        save();
+    }
+
+    public void reload() {
+        plugin.reloadConfig();
+        load();
+    }
+}

--- a/src/main/java/com/controlbro/claimy/model/ChunkKey.java
+++ b/src/main/java/com/controlbro/claimy/model/ChunkKey.java
@@ -1,0 +1,56 @@
+package com.controlbro.claimy.model;
+
+import java.util.Objects;
+
+public final class ChunkKey {
+    private final String world;
+    private final int x;
+    private final int z;
+
+    public ChunkKey(String world, int x, int z) {
+        this.world = world;
+        this.x = x;
+        this.z = z;
+    }
+
+    public String getWorld() {
+        return world;
+    }
+
+    public int getX() {
+        return x;
+    }
+
+    public int getZ() {
+        return z;
+    }
+
+    public String asString() {
+        return world + ":" + x + ":" + z;
+    }
+
+    public static ChunkKey fromString(String value) {
+        String[] parts = value.split(":");
+        if (parts.length != 3) {
+            throw new IllegalArgumentException("Invalid chunk key: " + value);
+        }
+        return new ChunkKey(parts[0], Integer.parseInt(parts[1]), Integer.parseInt(parts[2]));
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ChunkKey chunkKey = (ChunkKey) o;
+        return x == chunkKey.x && z == chunkKey.z && Objects.equals(world, chunkKey.world);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(world, x, z);
+    }
+}

--- a/src/main/java/com/controlbro/claimy/model/Town.java
+++ b/src/main/java/com/controlbro/claimy/model/Town.java
@@ -1,0 +1,71 @@
+package com.controlbro.claimy.model;
+
+import java.util.EnumMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+public class Town {
+    private final String name;
+    private final UUID owner;
+    private final Set<UUID> residents = new HashSet<>();
+    private final Set<String> allies = new HashSet<>();
+    private final Set<ChunkKey> chunks = new HashSet<>();
+    private final Map<TownFlag, Boolean> flags = new EnumMap<>(TownFlag.class);
+    private int chunkLimit;
+
+    public Town(String name, UUID owner, int chunkLimit) {
+        this.name = name;
+        this.owner = owner;
+        this.chunkLimit = chunkLimit;
+        this.residents.add(owner);
+        for (TownFlag flag : TownFlag.values()) {
+            flags.put(flag, true);
+        }
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public UUID getOwner() {
+        return owner;
+    }
+
+    public Set<UUID> getResidents() {
+        return residents;
+    }
+
+    public Set<String> getAllies() {
+        return allies;
+    }
+
+    public Set<ChunkKey> getChunks() {
+        return chunks;
+    }
+
+    public Map<TownFlag, Boolean> getFlags() {
+        return flags;
+    }
+
+    public boolean isResident(UUID uuid) {
+        return residents.contains(uuid);
+    }
+
+    public int getChunkLimit() {
+        return chunkLimit;
+    }
+
+    public void addChunkLimit(int amount) {
+        chunkLimit += amount;
+    }
+
+    public boolean isFlagEnabled(TownFlag flag) {
+        return flags.getOrDefault(flag, false);
+    }
+
+    public void setFlag(TownFlag flag, boolean value) {
+        flags.put(flag, value);
+    }
+}

--- a/src/main/java/com/controlbro/claimy/model/TownFlag.java
+++ b/src/main/java/com/controlbro/claimy/model/TownFlag.java
@@ -1,0 +1,7 @@
+package com.controlbro.claimy.model;
+
+public enum TownFlag {
+    ALLOW_ALLY_BUILD,
+    ALLOW_ALLY_DOORS,
+    ALLOW_ALLY_VILLAGERS
+}

--- a/src/main/java/com/controlbro/claimy/util/MessageUtil.java
+++ b/src/main/java/com/controlbro/claimy/util/MessageUtil.java
@@ -1,0 +1,23 @@
+package com.controlbro.claimy.util;
+
+import com.controlbro.claimy.ClaimyPlugin;
+import org.bukkit.ChatColor;
+import org.bukkit.command.CommandSender;
+
+public class MessageUtil {
+    private MessageUtil() {
+    }
+
+    public static void send(ClaimyPlugin plugin, CommandSender sender, String key, String... replacements) {
+        String message = plugin.getConfig().getString("messages." + key, "");
+        for (int i = 0; i + 1 < replacements.length; i += 2) {
+            message = message.replace("{" + replacements[i] + "}", replacements[i + 1]);
+        }
+        String prefix = plugin.getConfig().getString("messages.prefix", "");
+        sender.sendMessage(color(prefix + message));
+    }
+
+    public static String color(String message) {
+        return ChatColor.translateAlternateColorCodes('&', message);
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,0 +1,27 @@
+settings:
+  starting-chunk-allowance: 500
+  chunk-cost: 100.0
+  warning-cooldown-seconds: 30
+  show-border-particles: true
+  lock-doors-by-default: false
+  protect-pets:
+    enabled: true
+    worlds: ['world', 'world_nether', 'world_the_end']
+  disable-explosions-above-sea-level: true
+  mall:
+    require-town-for-mall-claim: false
+messages:
+  prefix: "&6[Claimy]&r "
+  no-town: "&cYou are not in a town."
+  town-created: "&aTown created: {town}"
+  town-deleted: "&cTown deleted."
+  invite-sent: "&aInvite sent to {player}."
+  invite-received: "&eYou have been invited to join {town}. Use /town accept {town}"
+  joined-town: "&aYou joined {town}."
+  kicked: "&c{player} was removed from the town."
+  claim-denied: "&cYou cannot build here."
+  claim-warning: "&eYou are building outside your claim. Use /town border to view your borders."
+  town-flag-updated: "&aFlag {flag} set to {value}."
+  chunk-bought: "&aBought {count} chunks for ${cost}."
+  not-enough-money: "&cYou need ${cost} to buy {count} chunks."
+  stuck-teleported: "&aYou were teleported outside the claim."

--- a/src/main/resources/gui.yml
+++ b/src/main/resources/gui.yml
@@ -1,0 +1,49 @@
+menu:
+  title: "&6Town Menu"
+  size: 27
+  items:
+    create:
+      slot: 10
+      material: "EMERALD_BLOCK"
+      name: "&aCreate Town"
+      lore:
+        - "&7Use /town create <name>"
+    delete:
+      slot: 11
+      material: "BARRIER"
+      name: "&cDelete Town"
+      lore:
+        - "&7Use /town delete"
+    invite:
+      slot: 12
+      material: "PAPER"
+      name: "&eInvite Player"
+      lore:
+        - "&7Use /town invite <player>"
+    kick:
+      slot: 13
+      material: "IRON_AXE"
+      name: "&cKick Player"
+      lore:
+        - "&7Use /town kick <player>"
+    border:
+      slot: 14
+      material: "MAP"
+      name: "&bShow Border"
+      lore:
+        - "&7Use /town border"
+    flags:
+      slot: 15
+      material: "REDSTONE_TORCH"
+      name: "&6Town Flags"
+      lore:
+        - "&7Click to edit flags"
+    buy:
+      slot: 16
+      material: "GOLD_INGOT"
+      name: "&6Buy Chunks"
+      lore:
+        - "&7Use /town buy <amount>"
+flags:
+  title: "&6Town Flags"
+  size: 27

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,0 +1,27 @@
+name: Claimy
+author: Controlbro
+main: com.controlbro.claimy.ClaimyPlugin
+version: 1.0.0
+api-version: '1.21'
+depend: [Vault]
+commands:
+  town:
+    description: Town management
+    usage: /town
+  townadmin:
+    description: Town admin management
+    usage: /townadmin
+    permission: claimy.admin
+  mall:
+    description: Mall management
+    usage: /mall
+  stuck:
+    description: Escape from a claim
+    usage: /stuck
+permissions:
+  claimy.admin:
+    description: Admin permissions for Claimy
+    default: op
+  claimy.use:
+    description: Use Claimy commands
+    default: true


### PR DESCRIPTION
- Added plugin scaffold and entrypoint `com.controlbro.claimy.ClaimyPlugin` with Vault economy setup and command registration for `town`, `townadmin`, `mall`, and `stuck`.  
- Implemented data models and managers: `Town`, `TownFlag`, `ChunkKey`, `TownManager` (town persistence and claim logic) and `MallManager` (plot definitions and ownership).  
- Implemented commands and GUI: `TownCommand`, `TownAdminCommand`, `MallCommand`, `StuckCommand`, `TownGui` and `TownBorderRenderer` with `gui.yml` and `config.yml` defaults and `MessageUtil` for localized messages.  
- Implemented protections in `ProtectionListener` for block/place/break, containers, doors, villagers, pistons, falling-block placement, portals, enderman, explosions above sea level, mall-vs-town interactions and the golden-shovel chunk claim tool, plus mall ownership checks and optional door locking via `settings.lock-doors-by-default`.