### PR TITLE
Add /town claim (manual + auto), vertical border particles, mall selection previews, and tab completion

### DIFF
--- a/src/main/java/com/controlbro/claimy/ClaimyPlugin.java
+++ b/src/main/java/com/controlbro/claimy/ClaimyPlugin.java
@@ -1,9 +1,13 @@
 package com.controlbro.claimy;
 
 import com.controlbro.claimy.commands.MallCommand;
+import com.controlbro.claimy.commands.MallTabCompleter;
 import com.controlbro.claimy.commands.StuckCommand;
+import com.controlbro.claimy.commands.StuckTabCompleter;
 import com.controlbro.claimy.commands.TownAdminCommand;
+import com.controlbro.claimy.commands.TownAdminTabCompleter;
 import com.controlbro.claimy.commands.TownCommand;
+import com.controlbro.claimy.commands.TownTabCompleter;
 import com.controlbro.claimy.gui.TownGui;
 import com.controlbro.claimy.listeners.ProtectionListener;
 import com.controlbro.claimy.managers.MallManager;
@@ -32,6 +36,11 @@ public class ClaimyPlugin extends JavaPlugin {
         getCommand("townadmin").setExecutor(new TownAdminCommand(this));
         getCommand("mall").setExecutor(new MallCommand(this));
         getCommand("stuck").setExecutor(new StuckCommand(this));
+
+        getCommand("town").setTabCompleter(new TownTabCompleter(this));
+        getCommand("townadmin").setTabCompleter(new TownAdminTabCompleter(this));
+        getCommand("mall").setTabCompleter(new MallTabCompleter(this));
+        getCommand("stuck").setTabCompleter(new StuckTabCompleter());
     }
 
     @Override

--- a/src/main/java/com/controlbro/claimy/commands/MallTabCompleter.java
+++ b/src/main/java/com/controlbro/claimy/commands/MallTabCompleter.java
@@ -1,0 +1,35 @@
+package com.controlbro.claimy.commands;
+
+import com.controlbro.claimy.ClaimyPlugin;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabCompleter;
+import org.bukkit.util.StringUtil;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class MallTabCompleter implements TabCompleter {
+    private final ClaimyPlugin plugin;
+
+    public MallTabCompleter(ClaimyPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
+        List<String> completions = new ArrayList<>();
+        if (args.length == 1) {
+            StringUtil.copyPartialMatches(args[0], List.of("claim"), completions);
+            return completions;
+        }
+        if (args.length == 2 && args[0].equalsIgnoreCase("claim")) {
+            List<String> ids = plugin.getMallManager().getPlotIds().stream()
+                    .map(String::valueOf)
+                    .collect(Collectors.toList());
+            StringUtil.copyPartialMatches(args[1], ids, completions);
+        }
+        return completions;
+    }
+}

--- a/src/main/java/com/controlbro/claimy/commands/StuckTabCompleter.java
+++ b/src/main/java/com/controlbro/claimy/commands/StuckTabCompleter.java
@@ -1,0 +1,15 @@
+package com.controlbro.claimy.commands;
+
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabCompleter;
+
+import java.util.Collections;
+import java.util.List;
+
+public class StuckTabCompleter implements TabCompleter {
+    @Override
+    public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
+        return Collections.emptyList();
+    }
+}

--- a/src/main/java/com/controlbro/claimy/commands/TownAdminCommand.java
+++ b/src/main/java/com/controlbro/claimy/commands/TownAdminCommand.java
@@ -61,6 +61,7 @@ public class TownAdminCommand implements CommandExecutor {
                     return true;
                 }
                 plugin.getMallManager().definePlot(id, region);
+                plugin.getMallManager().clearSelection(player.getUniqueId());
                 sender.sendMessage("Mall plot " + id + " set to selected region.");
                 playSuccess(player);
                 return true;

--- a/src/main/java/com/controlbro/claimy/commands/TownAdminTabCompleter.java
+++ b/src/main/java/com/controlbro/claimy/commands/TownAdminTabCompleter.java
@@ -1,0 +1,40 @@
+package com.controlbro.claimy.commands;
+
+import com.controlbro.claimy.ClaimyPlugin;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabCompleter;
+import org.bukkit.util.StringUtil;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class TownAdminTabCompleter implements TabCompleter {
+    private final ClaimyPlugin plugin;
+
+    public TownAdminTabCompleter(ClaimyPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
+        List<String> completions = new ArrayList<>();
+        if (args.length == 1) {
+            StringUtil.copyPartialMatches(args[0], List.of("reload", "mall"), completions);
+            return completions;
+        }
+        if (args.length == 2 && args[0].equalsIgnoreCase("mall")) {
+            StringUtil.copyPartialMatches(args[1], List.of("setplot", "clear"), completions);
+            return completions;
+        }
+        if (args.length == 3 && args[0].equalsIgnoreCase("mall") && args[1].equalsIgnoreCase("clear")) {
+            List<String> ids = plugin.getMallManager().getPlotIds().stream()
+                    .map(String::valueOf)
+                    .collect(Collectors.toList());
+            StringUtil.copyPartialMatches(args[2], ids, completions);
+            return completions;
+        }
+        return completions;
+    }
+}

--- a/src/main/java/com/controlbro/claimy/commands/TownTabCompleter.java
+++ b/src/main/java/com/controlbro/claimy/commands/TownTabCompleter.java
@@ -1,0 +1,66 @@
+package com.controlbro.claimy.commands;
+
+import com.controlbro.claimy.ClaimyPlugin;
+import com.controlbro.claimy.model.TownFlag;
+import org.bukkit.Bukkit;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabCompleter;
+import org.bukkit.entity.Player;
+import org.bukkit.util.StringUtil;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.stream.Collectors;
+
+public class TownTabCompleter implements TabCompleter {
+    private static final List<String> SUBCOMMANDS = Arrays.asList(
+            "create", "delete", "invite", "accept", "kick", "flag", "border", "help", "ally", "unally", "claim"
+    );
+
+    private final ClaimyPlugin plugin;
+
+    public TownTabCompleter(ClaimyPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
+        List<String> completions = new ArrayList<>();
+        if (args.length == 1) {
+            StringUtil.copyPartialMatches(args[0], SUBCOMMANDS, completions);
+            return completions;
+        }
+        String sub = args[0].toLowerCase(Locale.ROOT);
+        if (args.length == 2) {
+            switch (sub) {
+                case "invite", "kick" -> {
+                    StringUtil.copyPartialMatches(args[1], Bukkit.getOnlinePlayers().stream()
+                            .map(Player::getName)
+                            .collect(Collectors.toList()), completions);
+                }
+                case "ally", "unally", "accept" -> {
+                    StringUtil.copyPartialMatches(args[1], plugin.getTownManager().getTownNames(), completions);
+                }
+                case "flag" -> {
+                    List<String> flags = Arrays.stream(TownFlag.values())
+                            .map(flag -> flag.name().toLowerCase(Locale.ROOT))
+                            .collect(Collectors.toList());
+                    StringUtil.copyPartialMatches(args[1], flags, completions);
+                }
+                case "claim" -> {
+                    StringUtil.copyPartialMatches(args[1], List.of("auto"), completions);
+                }
+                default -> {
+                }
+            }
+            return completions;
+        }
+        if (args.length == 3 && "flag".equals(sub)) {
+            StringUtil.copyPartialMatches(args[2], List.of("true", "false"), completions);
+        }
+        return completions;
+    }
+}

--- a/src/main/java/com/controlbro/claimy/gui/MallSelectionRenderer.java
+++ b/src/main/java/com/controlbro/claimy/gui/MallSelectionRenderer.java
@@ -1,0 +1,59 @@
+package com.controlbro.claimy.gui;
+
+import com.controlbro.claimy.model.Region;
+import org.bukkit.Color;
+import org.bukkit.Location;
+import org.bukkit.Particle;
+import org.bukkit.World;
+import org.bukkit.entity.Player;
+
+public class MallSelectionRenderer {
+    private MallSelectionRenderer() {
+    }
+
+    public static void render(Player player, Location primary, Location secondary) {
+        if (primary == null) {
+            return;
+        }
+        if (secondary == null || !primary.getWorld().equals(secondary.getWorld())) {
+            spawnColumn(player, primary.getWorld(), primary.getBlockX(), primary.getBlockY(), primary.getBlockZ(),
+                    primary.getWorld().getMaxHeight());
+            return;
+        }
+        Region region = new Region(
+                primary.getWorld().getName(),
+                primary.getBlockX(),
+                primary.getBlockY(),
+                primary.getBlockZ(),
+                secondary.getBlockX(),
+                secondary.getBlockY(),
+                secondary.getBlockZ()
+        );
+        World world = primary.getWorld();
+        int minX = region.getMinX();
+        int maxX = region.getMaxX();
+        int minZ = region.getMinZ();
+        int maxZ = region.getMaxZ();
+        int minY = region.getMinY();
+        int maxY = region.getMaxY();
+        for (int x = minX; x <= maxX; x++) {
+            spawnColumn(player, world, x, minY, minZ, maxY);
+            spawnColumn(player, world, x, minY, maxZ, maxY);
+        }
+        for (int z = minZ; z <= maxZ; z++) {
+            spawnColumn(player, world, minX, minY, z, maxY);
+            spawnColumn(player, world, maxX, minY, z, maxY);
+        }
+    }
+
+    private static void spawnColumn(Player player, World world, int x, int startY, int z, int endY) {
+        int step = 3;
+        int maxY = Math.max(startY, endY);
+        int minY = Math.min(startY, endY);
+        for (int y = minY; y <= maxY; y += step) {
+            Location location = new Location(world, x + 0.5, y + 0.5, z + 0.5);
+            player.spawnParticle(Particle.DUST, location, 2, 0.15, 0.15, 0.15, 0,
+                    new Particle.DustOptions(Color.AQUA, 1.2f));
+        }
+    }
+}

--- a/src/main/java/com/controlbro/claimy/gui/TownBorderRenderer.java
+++ b/src/main/java/com/controlbro/claimy/gui/TownBorderRenderer.java
@@ -26,21 +26,25 @@ public class TownBorderRenderer {
             int minZ = key.getZ() << 4;
             int maxX = minX + 15;
             int maxZ = minZ + 15;
+            int maxY = world.getMaxHeight();
             for (int x = minX; x <= maxX; x++) {
-                spawn(world, x, minZ, player);
-                spawn(world, x, maxZ, player);
+                spawnColumn(world, x, minZ, maxY, player);
+                spawnColumn(world, x, maxZ, maxY, player);
             }
             for (int z = minZ; z <= maxZ; z++) {
-                spawn(world, minX, z, player);
-                spawn(world, maxX, z, player);
+                spawnColumn(world, minX, z, maxY, player);
+                spawnColumn(world, maxX, z, maxY, player);
             }
         }
     }
 
-    private static void spawn(World world, int x, int z, Player player) {
+    private static void spawnColumn(World world, int x, int z, int maxY, Player player) {
         int y = world.getHighestBlockYAt(x, z) + 1;
-        Location location = new Location(world, x + 0.5, y, z + 0.5);
-        player.spawnParticle(Particle.DUST, location, 8, 0.2, 0.2, 0.2, 0,
-                new Particle.DustOptions(org.bukkit.Color.LIME, 1.5f));
+        int step = 4;
+        for (int currentY = y; currentY <= maxY; currentY += step) {
+            Location location = new Location(world, x + 0.5, currentY, z + 0.5);
+            player.spawnParticle(Particle.DUST, location, 4, 0.2, 0.2, 0.2, 0,
+                    new Particle.DustOptions(org.bukkit.Color.LIME, 1.5f));
+        }
     }
 }

--- a/src/main/java/com/controlbro/claimy/model/Region.java
+++ b/src/main/java/com/controlbro/claimy/model/Region.java
@@ -25,6 +25,30 @@ public class Region {
         return world;
     }
 
+    public int getMinX() {
+        return minX;
+    }
+
+    public int getMinY() {
+        return minY;
+    }
+
+    public int getMinZ() {
+        return minZ;
+    }
+
+    public int getMaxX() {
+        return maxX;
+    }
+
+    public int getMaxY() {
+        return maxY;
+    }
+
+    public int getMaxZ() {
+        return maxZ;
+    }
+
     public boolean contains(Location location) {
         if (!location.getWorld().getName().equals(world)) {
             return false;


### PR DESCRIPTION
- Added auto-claiming support in `TownManager` with `autoClaiming` state and methods `isAutoClaiming`, `toggleAutoClaim`, and `stopAutoClaim`, and prevented joining multiple towns in `addResident`.
- Implemented `/town claim` and `/town claim auto` in `TownCommand` and updated help text to include claim commands, with server-side checks using existing mall and buffer logic.
- Hooked movement-based auto-claiming in `ProtectionListener` via `PlayerMoveEvent`, extracted claim logic to `attemptClaim(...)`, and reuse it for shovel-based manual claims; stop preview on player quit.
- Rendered vertical town border walls by updating `TownBorderRenderer` to spawn particle columns up to `world.getMaxHeight()` and added `MallSelectionRenderer` to display mall plot selection vertical borders.
- Added mall selection preview lifecycle in `MallManager` (`startSelectionPreview`, `stopSelectionPreview`, `clearSelection`) with scheduled preview tasks and cleared selection after `townadmin mall setplot`.
- Added tab-completers `TownTabCompleter`, `TownAdminTabCompleter`, `MallTabCompleter`, and `StuckTabCompleter`, and registered them in `ClaimyPlugin`.
- Exposed region bounds getters in `Region` and added utility `getTownNames()` to provide town name suggestions.
- Cleaned up auto-claim state when residents are removed or towns deleted.