### PR TITLE
Add resident permissions, mall employees, and Squaremap support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,12 @@
             <version>${paper.version}</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>xyz.jpenilla</groupId>
+            <artifactId>squaremap-api</artifactId>
+            <version>1.2.4</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/controlbro/claimy/ClaimyPlugin.java
+++ b/src/main/java/com/controlbro/claimy/ClaimyPlugin.java
@@ -8,8 +8,12 @@ import com.controlbro.claimy.commands.TownAdminCommand;
 import com.controlbro.claimy.commands.TownAdminTabCompleter;
 import com.controlbro.claimy.commands.TownCommand;
 import com.controlbro.claimy.commands.TownTabCompleter;
+import com.controlbro.claimy.gui.MallGui;
 import com.controlbro.claimy.gui.TownGui;
 import com.controlbro.claimy.listeners.ProtectionListener;
+import com.controlbro.claimy.map.MapIntegration;
+import com.controlbro.claimy.map.NoopMapIntegration;
+import com.controlbro.claimy.map.SquaremapIntegration;
 import com.controlbro.claimy.managers.MallManager;
 import com.controlbro.claimy.managers.TownManager;
 import org.bukkit.Bukkit;
@@ -19,6 +23,8 @@ public class ClaimyPlugin extends JavaPlugin {
     private TownManager townManager;
     private MallManager mallManager;
     private TownGui townGui;
+    private MallGui mallGui;
+    private MapIntegration mapIntegration = new NoopMapIntegration();
 
     @Override
     public void onEnable() {
@@ -28,9 +34,16 @@ public class ClaimyPlugin extends JavaPlugin {
         this.townManager = new TownManager(this);
         this.mallManager = new MallManager(this);
         this.townGui = new TownGui(this);
+        this.mallGui = new MallGui(this);
+
+        if (getConfig().getBoolean("settings.squaremap.enabled")
+                && Bukkit.getPluginManager().getPlugin("squaremap") != null) {
+            this.mapIntegration = new SquaremapIntegration(this);
+        }
 
         Bukkit.getPluginManager().registerEvents(new ProtectionListener(this), this);
         Bukkit.getPluginManager().registerEvents(townGui, this);
+        Bukkit.getPluginManager().registerEvents(mallGui, this);
 
         getCommand("town").setExecutor(new TownCommand(this));
         getCommand("townadmin").setExecutor(new TownAdminCommand(this));
@@ -41,6 +54,8 @@ public class ClaimyPlugin extends JavaPlugin {
         getCommand("townadmin").setTabCompleter(new TownAdminTabCompleter(this));
         getCommand("mall").setTabCompleter(new MallTabCompleter(this));
         getCommand("stuck").setTabCompleter(new StuckTabCompleter());
+
+        mapIntegration.refreshAll();
     }
 
     @Override
@@ -59,6 +74,14 @@ public class ClaimyPlugin extends JavaPlugin {
 
     public TownGui getTownGui() {
         return townGui;
+    }
+
+    public MallGui getMallGui() {
+        return mallGui;
+    }
+
+    public MapIntegration getMapIntegration() {
+        return mapIntegration;
     }
 
 }

--- a/src/main/java/com/controlbro/claimy/commands/MallTabCompleter.java
+++ b/src/main/java/com/controlbro/claimy/commands/MallTabCompleter.java
@@ -1,13 +1,17 @@
 package com.controlbro.claimy.commands;
 
 import com.controlbro.claimy.ClaimyPlugin;
+import com.controlbro.claimy.util.MapColorUtil;
+import org.bukkit.Bukkit;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.TabCompleter;
+import org.bukkit.entity.Player;
 import org.bukkit.util.StringUtil;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.stream.Collectors;
 
 public class MallTabCompleter implements TabCompleter {
@@ -21,14 +25,27 @@ public class MallTabCompleter implements TabCompleter {
     public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
         List<String> completions = new ArrayList<>();
         if (args.length == 1) {
-            StringUtil.copyPartialMatches(args[0], List.of("claim"), completions);
+            StringUtil.copyPartialMatches(args[0], List.of("claim", "config", "color", "employee"), completions);
             return completions;
         }
-        if (args.length == 2 && args[0].equalsIgnoreCase("claim")) {
-            List<String> ids = plugin.getMallManager().getPlotIds().stream()
-                    .map(String::valueOf)
-                    .collect(Collectors.toList());
-            StringUtil.copyPartialMatches(args[1], ids, completions);
+        if (args.length == 2) {
+            String sub = args[0].toLowerCase(Locale.ROOT);
+            if (sub.equals("claim") || sub.equals("config")) {
+                List<String> ids = plugin.getMallManager().getPlotIds().stream()
+                        .map(String::valueOf)
+                        .collect(Collectors.toList());
+                StringUtil.copyPartialMatches(args[1], ids, completions);
+            } else if (sub.equals("color")) {
+                StringUtil.copyPartialMatches(args[1], MapColorUtil.getNamedColors().keySet(), completions);
+            } else if (sub.equals("employee")) {
+                StringUtil.copyPartialMatches(args[1], List.of("add", "remove"), completions);
+            }
+            return completions;
+        }
+        if (args.length == 3 && args[0].equalsIgnoreCase("employee")) {
+            StringUtil.copyPartialMatches(args[2], Bukkit.getOnlinePlayers().stream()
+                    .map(Player::getName)
+                    .collect(Collectors.toList()), completions);
         }
         return completions;
     }

--- a/src/main/java/com/controlbro/claimy/commands/TownTabCompleter.java
+++ b/src/main/java/com/controlbro/claimy/commands/TownTabCompleter.java
@@ -1,7 +1,10 @@
 package com.controlbro.claimy.commands;
 
 import com.controlbro.claimy.ClaimyPlugin;
+import com.controlbro.claimy.model.ResidentPermission;
+import com.controlbro.claimy.model.Town;
 import com.controlbro.claimy.model.TownFlag;
+import com.controlbro.claimy.util.MapColorUtil;
 import org.bukkit.Bukkit;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
@@ -13,11 +16,13 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 public class TownTabCompleter implements TabCompleter {
     private static final List<String> SUBCOMMANDS = Arrays.asList(
-            "create", "delete", "invite", "accept", "kick", "flag", "border", "help", "ally", "unally", "claim"
+            "create", "delete", "invite", "accept", "kick", "flag", "border", "help", "ally", "unally", "claim",
+            "resident", "color"
     );
 
     private final ClaimyPlugin plugin;
@@ -59,13 +64,40 @@ public class TownTabCompleter implements TabCompleter {
                 case "delete" -> {
                     StringUtil.copyPartialMatches(args[1], List.of("confirm"), completions);
                 }
+                case "resident" -> {
+                    if (sender instanceof Player player) {
+                        Optional<Town> town = plugin.getTownManager().getTown(player.getUniqueId());
+                        if (town.isPresent()) {
+                            List<String> names = town.get().getResidents().stream()
+                                    .map(Bukkit::getOfflinePlayer)
+                                    .map(offline -> offline.getName() == null ? "" : offline.getName())
+                                    .filter(name -> !name.isBlank())
+                                    .collect(Collectors.toList());
+                            StringUtil.copyPartialMatches(args[1], names, completions);
+                        }
+                    }
+                }
+                case "color" -> {
+                    StringUtil.copyPartialMatches(args[1], MapColorUtil.getNamedColors().keySet(), completions);
+                }
                 default -> {
                 }
             }
             return completions;
         }
-        if (args.length == 3 && "flag".equals(sub)) {
-            StringUtil.copyPartialMatches(args[2], List.of("true", "false"), completions);
+        if (args.length == 3) {
+            if ("flag".equals(sub)) {
+                StringUtil.copyPartialMatches(args[2], List.of("true", "false"), completions);
+            }
+            if ("resident".equals(sub)) {
+                List<String> permissions = Arrays.stream(ResidentPermission.values())
+                        .map(permission -> permission.name().toLowerCase(Locale.ROOT))
+                        .collect(Collectors.toList());
+                StringUtil.copyPartialMatches(args[2], permissions, completions);
+            }
+        }
+        if (args.length == 4 && "resident".equals(sub)) {
+            StringUtil.copyPartialMatches(args[3], List.of("true", "false"), completions);
         }
         return completions;
     }

--- a/src/main/java/com/controlbro/claimy/gui/MallGui.java
+++ b/src/main/java/com/controlbro/claimy/gui/MallGui.java
@@ -1,0 +1,194 @@
+package com.controlbro.claimy.gui;
+
+import com.controlbro.claimy.ClaimyPlugin;
+import com.controlbro.claimy.util.MessageUtil;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.player.AsyncPlayerChatEvent;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+public class MallGui implements Listener {
+    private final ClaimyPlugin plugin;
+    private YamlConfiguration guiConfig;
+    private final Map<UUID, Integer> openPlots = new HashMap<>();
+    private final Map<UUID, PendingEmployeeAction> pendingActions = new HashMap<>();
+
+    public MallGui(ClaimyPlugin plugin) {
+        this.plugin = plugin;
+        reload();
+    }
+
+    public void reload() {
+        File file = new File(plugin.getDataFolder(), "gui.yml");
+        guiConfig = YamlConfiguration.loadConfiguration(file);
+    }
+
+    public void openConfig(Player player, int plotId) {
+        ConfigurationSection section = guiConfig.getConfigurationSection("mall-config");
+        if (section == null) {
+            player.sendMessage("Mall config GUI is missing from gui.yml.");
+            return;
+        }
+        String title = MessageUtil.color(section.getString("title", "Mall Plot"));
+        int size = section.getInt("size", 27);
+        Inventory inventory = Bukkit.createInventory(player, size, title);
+        ConfigurationSection items = section.getConfigurationSection("items");
+        if (items != null) {
+            for (String key : items.getKeys(false)) {
+                ConfigurationSection itemSection = items.getConfigurationSection(key);
+                if (itemSection == null) {
+                    continue;
+                }
+                int slot = itemSection.getInt("slot");
+                Material material = Material.matchMaterial(itemSection.getString("material", "STONE"));
+                ItemStack stack = new ItemStack(material == null ? Material.STONE : material);
+                ItemMeta meta = stack.getItemMeta();
+                meta.setDisplayName(MessageUtil.color(itemSection.getString("name", key)));
+                List<String> lore = new ArrayList<>();
+                for (String line : itemSection.getStringList("lore")) {
+                    lore.add(MessageUtil.color(replaceEmployees(plotId, line)));
+                }
+                meta.setLore(lore);
+                stack.setItemMeta(meta);
+                inventory.setItem(slot, stack);
+            }
+        }
+        openPlots.put(player.getUniqueId(), plotId);
+        player.openInventory(inventory);
+    }
+
+    @EventHandler
+    public void onInventoryClick(InventoryClickEvent event) {
+        if (!(event.getWhoClicked() instanceof Player player)) {
+            return;
+        }
+        ConfigurationSection section = guiConfig.getConfigurationSection("mall-config");
+        if (section == null) {
+            return;
+        }
+        String title = MessageUtil.color(section.getString("title", "Mall Plot"));
+        if (!event.getView().getTitle().equals(title)) {
+            return;
+        }
+        event.setCancelled(true);
+        if (event.getCurrentItem() == null) {
+            return;
+        }
+        Integer plotId = openPlots.get(player.getUniqueId());
+        if (plotId == null) {
+            return;
+        }
+        ConfigurationSection items = section.getConfigurationSection("items");
+        if (items == null) {
+            return;
+        }
+        int slot = event.getSlot();
+        for (String key : items.getKeys(false)) {
+            ConfigurationSection itemSection = items.getConfigurationSection(key);
+            if (itemSection == null) {
+                continue;
+            }
+            int itemSlot = itemSection.getInt("slot");
+            if (slot != itemSlot) {
+                continue;
+            }
+            if (key.equalsIgnoreCase("add-employee")) {
+                pendingActions.put(player.getUniqueId(), new PendingEmployeeAction(plotId, EmployeeAction.ADD));
+                player.closeInventory();
+                player.sendMessage("Type the player name to add as an employee (or type 'cancel').");
+                return;
+            }
+            if (key.equalsIgnoreCase("remove-employee")) {
+                pendingActions.put(player.getUniqueId(), new PendingEmployeeAction(plotId, EmployeeAction.REMOVE));
+                player.closeInventory();
+                player.sendMessage("Type the player name to remove from employees (or type 'cancel').");
+                return;
+            }
+        }
+    }
+
+    @EventHandler
+    public void onChat(AsyncPlayerChatEvent event) {
+        PendingEmployeeAction action = pendingActions.remove(event.getPlayer().getUniqueId());
+        if (action == null) {
+            return;
+        }
+        event.setCancelled(true);
+        String message = event.getMessage().trim();
+        if (message.equalsIgnoreCase("cancel")) {
+            event.getPlayer().sendMessage("Mall employee update cancelled.");
+            return;
+        }
+        Bukkit.getScheduler().runTask(plugin, () -> handleEmployeeAction(event.getPlayer(), action, message));
+    }
+
+    private void handleEmployeeAction(Player player, PendingEmployeeAction action, String playerName) {
+        Optional<UUID> owner = plugin.getMallManager().getPlotOwner(action.plotId);
+        if (owner.isEmpty() || !owner.get().equals(player.getUniqueId())) {
+            player.sendMessage("You do not own that mall plot.");
+            return;
+        }
+        OfflinePlayer target = Bukkit.getOfflinePlayer(playerName);
+        if (target.getName() == null) {
+            player.sendMessage("Player not found.");
+            return;
+        }
+        UUID targetId = target.getUniqueId();
+        if (action.action == EmployeeAction.ADD) {
+            if (plugin.getMallManager().addEmployee(action.plotId, targetId)) {
+                player.sendMessage("Added " + target.getName() + " as an employee.");
+            } else {
+                player.sendMessage("Unable to add that employee.");
+            }
+        } else {
+            if (plugin.getMallManager().removeEmployee(action.plotId, targetId)) {
+                player.sendMessage("Removed " + target.getName() + " from employees.");
+            } else {
+                player.sendMessage("Unable to remove that employee.");
+            }
+        }
+        openConfig(player, action.plotId);
+    }
+
+    private String replaceEmployees(int plotId, String line) {
+        if (!line.contains("{employees}")) {
+            return line;
+        }
+        List<String> names = new ArrayList<>();
+        for (UUID employeeId : plugin.getMallManager().getPlotEmployees(plotId)) {
+            OfflinePlayer employee = Bukkit.getOfflinePlayer(employeeId);
+            if (employee.getName() != null) {
+                names.add(employee.getName());
+            } else {
+                names.add(employeeId.toString());
+            }
+        }
+        String value = names.isEmpty() ? "None" : String.join(", ", names);
+        return line.replace("{employees}", value);
+    }
+
+    private record PendingEmployeeAction(int plotId, EmployeeAction action) {
+    }
+
+    private enum EmployeeAction {
+        ADD,
+        REMOVE
+    }
+}

--- a/src/main/java/com/controlbro/claimy/listeners/ProtectionListener.java
+++ b/src/main/java/com/controlbro/claimy/listeners/ProtectionListener.java
@@ -2,6 +2,7 @@ package com.controlbro.claimy.listeners;
 
 import org.bukkit.Chunk;
 import com.controlbro.claimy.ClaimyPlugin;
+import com.controlbro.claimy.model.ResidentPermission;
 import com.controlbro.claimy.model.Town;
 import com.controlbro.claimy.model.TownFlag;
 import com.controlbro.claimy.util.MessageUtil;
@@ -351,7 +352,7 @@ public class ProtectionListener implements Listener {
             return true;
         }
         if (plugin.getMallManager().isInMall(block.getLocation())) {
-            return plugin.getMallManager().isMallOwner(block.getLocation(), player.getUniqueId());
+            return plugin.getMallManager().isMallMember(block.getLocation(), player.getUniqueId());
         }
         Optional<Town> townOptional = plugin.getTownManager().getTownAt(block.getLocation());
         if (townOptional.isEmpty()) {
@@ -359,7 +360,7 @@ public class ProtectionListener implements Listener {
         }
         Town town = townOptional.get();
         if (town.isResident(player.getUniqueId())) {
-            return true;
+            return town.isResidentPermissionEnabled(player.getUniqueId(), ResidentPermission.BUILD);
         }
         Optional<Town> playerTown = plugin.getTownManager().getTown(player.getUniqueId());
         if (playerTown.isPresent()) {
@@ -376,7 +377,7 @@ public class ProtectionListener implements Listener {
             return true;
         }
         if (plugin.getMallManager().isInMall(block.getLocation())) {
-            return plugin.getMallManager().isMallOwner(block.getLocation(), player.getUniqueId());
+            return plugin.getMallManager().isMallMember(block.getLocation(), player.getUniqueId());
         }
         Optional<Town> townOptional = plugin.getTownManager().getTownAt(block.getLocation());
         if (townOptional.isEmpty()) {
@@ -384,7 +385,7 @@ public class ProtectionListener implements Listener {
         }
         Town town = townOptional.get();
         if (town.isResident(player.getUniqueId())) {
-            return true;
+            return town.isResidentPermissionEnabled(player.getUniqueId(), ResidentPermission.CONTAINERS);
         }
         Optional<Town> playerTown = plugin.getTownManager().getTown(player.getUniqueId());
         if (playerTown.isPresent()) {
@@ -401,7 +402,7 @@ public class ProtectionListener implements Listener {
             return true;
         }
         if (plugin.getMallManager().isInMall(block.getLocation())) {
-            return plugin.getMallManager().isMallOwner(block.getLocation(), player.getUniqueId());
+            return plugin.getMallManager().isMallMember(block.getLocation(), player.getUniqueId());
         }
         Optional<Town> townOptional = plugin.getTownManager().getTownAt(block.getLocation());
         if (townOptional.isEmpty()) {
@@ -409,7 +410,7 @@ public class ProtectionListener implements Listener {
         }
         Town town = townOptional.get();
         if (town.isResident(player.getUniqueId())) {
-            return true;
+            return town.isResidentPermissionEnabled(player.getUniqueId(), ResidentPermission.DOORS);
         }
         Optional<Town> playerTown = plugin.getTownManager().getTown(player.getUniqueId());
         if (playerTown.isPresent()) {
@@ -425,17 +426,24 @@ public class ProtectionListener implements Listener {
         if (player.hasPermission("claimy.admin")) {
             return true;
         }
+        if (plugin.getMallManager().isInMall(block.getLocation())) {
+            return plugin.getMallManager().isMallMember(block.getLocation(), player.getUniqueId());
+        }
         Optional<Town> townOptional = plugin.getTownManager().getTownAt(block.getLocation());
         if (townOptional.isEmpty()) {
             return true;
         }
         Town town = townOptional.get();
-        return town.isResident(player.getUniqueId());
+        return town.isResident(player.getUniqueId())
+                && town.isResidentPermissionEnabled(player.getUniqueId(), ResidentPermission.BEDS);
     }
 
     private boolean canUseRedstone(Player player, Block block) {
         if (player.hasPermission("claimy.admin")) {
             return true;
+        }
+        if (plugin.getMallManager().isInMall(block.getLocation())) {
+            return plugin.getMallManager().isMallMember(block.getLocation(), player.getUniqueId());
         }
         Optional<Town> townOptional = plugin.getTownManager().getTownAt(block.getLocation());
         if (townOptional.isEmpty()) {
@@ -443,7 +451,7 @@ public class ProtectionListener implements Listener {
         }
         Town town = townOptional.get();
         if (town.isResident(player.getUniqueId())) {
-            return true;
+            return town.isResidentPermissionEnabled(player.getUniqueId(), ResidentPermission.REDSTONE);
         }
         Optional<Town> playerTown = plugin.getTownManager().getTown(player.getUniqueId());
         if (playerTown.isPresent()) {
@@ -463,13 +471,16 @@ public class ProtectionListener implements Listener {
         if (player.hasPermission("claimy.admin")) {
             return true;
         }
+        if (plugin.getMallManager().isInMall(entity.getLocation())) {
+            return plugin.getMallManager().isMallMember(entity.getLocation(), player.getUniqueId());
+        }
         Optional<Town> townOptional = plugin.getTownManager().getTownAt(entity.getLocation());
         if (townOptional.isEmpty()) {
             return true;
         }
         Town town = townOptional.get();
         if (town.isResident(player.getUniqueId())) {
-            return true;
+            return town.isResidentPermissionEnabled(player.getUniqueId(), ResidentPermission.VILLAGERS);
         }
         Optional<Town> playerTown = plugin.getTownManager().getTown(player.getUniqueId());
         if (playerTown.isPresent()) {

--- a/src/main/java/com/controlbro/claimy/managers/MallManager.java
+++ b/src/main/java/com/controlbro/claimy/managers/MallManager.java
@@ -11,8 +11,10 @@ import org.bukkit.configuration.file.YamlConfiguration;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -24,6 +26,8 @@ public class MallManager {
     private YamlConfiguration config;
     private final Map<Integer, Region> plots = new HashMap<>();
     private final Map<Integer, UUID> plotOwners = new HashMap<>();
+    private final Map<Integer, Set<UUID>> plotEmployees = new HashMap<>();
+    private final Map<Integer, String> plotColors = new HashMap<>();
     private final Map<UUID, Location> selectionPrimary = new HashMap<>();
     private final Map<UUID, Location> selectionSecondary = new HashMap<>();
     private final Map<UUID, Integer> selectionTasks = new HashMap<>();
@@ -46,6 +50,8 @@ public class MallManager {
         config = YamlConfiguration.loadConfiguration(file);
         plots.clear();
         plotOwners.clear();
+        plotEmployees.clear();
+        plotColors.clear();
         ConfigurationSection plotsSection = config.getConfigurationSection("plots");
         if (plotsSection == null) {
             return;
@@ -64,6 +70,15 @@ public class MallManager {
             if (owner != null && !owner.isBlank()) {
                 plotOwners.put(id, UUID.fromString(owner));
             }
+            plotColors.put(id, section.getString("color"));
+            List<String> employees = section.getStringList("employees");
+            if (!employees.isEmpty()) {
+                Set<UUID> employeeSet = new HashSet<>();
+                for (String employeeId : employees) {
+                    employeeSet.add(UUID.fromString(employeeId));
+                }
+                plotEmployees.put(id, employeeSet);
+            }
         }
     }
 
@@ -77,6 +92,18 @@ public class MallManager {
             if (owner != null) {
                 section.set("owner", owner.toString());
             }
+            Set<UUID> employees = plotEmployees.get(entry.getKey());
+            if (employees != null && !employees.isEmpty()) {
+                List<String> employeeList = new ArrayList<>();
+                for (UUID employee : employees) {
+                    employeeList.add(employee.toString());
+                }
+                section.set("employees", employeeList);
+            }
+            String color = plotColors.get(entry.getKey());
+            if (color != null) {
+                section.set("color", color);
+            }
         }
         try {
             config.save(file);
@@ -88,6 +115,7 @@ public class MallManager {
     public void definePlot(int id, Region region) {
         plots.put(id, region);
         save();
+        plugin.getMapIntegration().refreshAll();
     }
 
     public Optional<Region> getPlotRegion(int id) {
@@ -105,8 +133,12 @@ public class MallManager {
         if (plotOwners.containsKey(id)) {
             return false;
         }
+        if (isEmployee(playerId)) {
+            return false;
+        }
         plotOwners.put(id, playerId);
         save();
+        plugin.getMapIntegration().refreshAll();
         return true;
     }
 
@@ -128,9 +160,79 @@ public class MallManager {
         return plotId.isPresent() && playerId.equals(plotOwners.get(plotId.get()));
     }
 
+    public boolean isMallMember(Location location, UUID playerId) {
+        Optional<Integer> plotId = getPlotAt(location);
+        if (plotId.isEmpty()) {
+            return false;
+        }
+        int id = plotId.get();
+        return playerId.equals(plotOwners.get(id)) || isPlotEmployee(id, playerId);
+    }
+
     public void clearPlotOwner(int id) {
         plotOwners.remove(id);
+        plotEmployees.remove(id);
         save();
+        plugin.getMapIntegration().refreshAll();
+    }
+
+    public boolean addEmployee(int id, UUID employeeId) {
+        if (!plots.containsKey(id)) {
+            return false;
+        }
+        if (plotOwners.containsKey(id) && plotOwners.get(id).equals(employeeId)) {
+            return false;
+        }
+        if (isPlotOwner(employeeId)) {
+            return false;
+        }
+        Set<UUID> employees = plotEmployees.computeIfAbsent(id, key -> new HashSet<>());
+        if (employees.add(employeeId)) {
+            save();
+            return true;
+        }
+        return false;
+    }
+
+    public boolean removeEmployee(int id, UUID employeeId) {
+        Set<UUID> employees = plotEmployees.get(id);
+        if (employees != null && employees.remove(employeeId)) {
+            save();
+            return true;
+        }
+        return false;
+    }
+
+    public boolean isEmployee(UUID playerId) {
+        for (Set<UUID> employees : plotEmployees.values()) {
+            if (employees.contains(playerId)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public boolean isPlotOwner(UUID playerId) {
+        return plotOwners.containsValue(playerId);
+    }
+
+    public boolean isPlotEmployee(int id, UUID playerId) {
+        Set<UUID> employees = plotEmployees.get(id);
+        return employees != null && employees.contains(playerId);
+    }
+
+    public Set<UUID> getPlotEmployees(int id) {
+        return new HashSet<>(plotEmployees.getOrDefault(id, Set.of()));
+    }
+
+    public Optional<String> getPlotColor(int id) {
+        return Optional.ofNullable(plotColors.get(id));
+    }
+
+    public void setPlotColor(int id, String color) {
+        plotColors.put(id, color);
+        save();
+        plugin.getMapIntegration().refreshAll();
     }
 
     public void setPrimarySelection(UUID playerId, Location location) {
@@ -198,5 +300,9 @@ public class MallManager {
 
     public Set<Integer> getPlotIds() {
         return new HashSet<>(plots.keySet());
+    }
+
+    public Map<Integer, Region> getPlots() {
+        return new HashMap<>(plots);
     }
 }

--- a/src/main/java/com/controlbro/claimy/map/MapIntegration.java
+++ b/src/main/java/com/controlbro/claimy/map/MapIntegration.java
@@ -1,0 +1,5 @@
+package com.controlbro.claimy.map;
+
+public interface MapIntegration {
+    void refreshAll();
+}

--- a/src/main/java/com/controlbro/claimy/map/NoopMapIntegration.java
+++ b/src/main/java/com/controlbro/claimy/map/NoopMapIntegration.java
@@ -1,0 +1,8 @@
+package com.controlbro.claimy.map;
+
+public class NoopMapIntegration implements MapIntegration {
+    @Override
+    public void refreshAll() {
+        // no-op
+    }
+}

--- a/src/main/java/com/controlbro/claimy/map/SquaremapIntegration.java
+++ b/src/main/java/com/controlbro/claimy/map/SquaremapIntegration.java
@@ -1,0 +1,189 @@
+package com.controlbro.claimy.map;
+
+import com.controlbro.claimy.ClaimyPlugin;
+import com.controlbro.claimy.model.ChunkKey;
+import com.controlbro.claimy.model.Region;
+import com.controlbro.claimy.model.Town;
+import com.controlbro.claimy.util.MapColorUtil;
+import org.bukkit.Bukkit;
+import org.bukkit.World;
+import xyz.jpenilla.squaremap.api.BukkitAdapter;
+import xyz.jpenilla.squaremap.api.Key;
+import xyz.jpenilla.squaremap.api.Point;
+import xyz.jpenilla.squaremap.api.SquaremapProvider;
+import xyz.jpenilla.squaremap.api.WorldIdentifier;
+import xyz.jpenilla.squaremap.api.marker.MultiPolygon;
+import xyz.jpenilla.squaremap.api.marker.MarkerOptions;
+import xyz.jpenilla.squaremap.api.SimpleLayerProvider;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+public class SquaremapIntegration implements MapIntegration {
+    private static final String TOWN_LAYER_KEY = "claimy_towns";
+    private static final String MALL_LAYER_KEY = "claimy_mall";
+    private final ClaimyPlugin plugin;
+
+    public SquaremapIntegration(ClaimyPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public void refreshAll() {
+        if (!plugin.getConfig().getBoolean("settings.squaremap.enabled")) {
+            return;
+        }
+        for (World world : Bukkit.getWorlds()) {
+            updateWorld(world);
+        }
+    }
+
+    private void updateWorld(World world) {
+        WorldIdentifier worldId = BukkitAdapter.worldIdentifier(world);
+        Optional<xyz.jpenilla.squaremap.api.MapWorld> mapWorld = SquaremapProvider.get().getWorldIfEnabled(worldId);
+        if (mapWorld.isEmpty()) {
+            return;
+        }
+        updateTownLayer(mapWorld.get(), world);
+        updateMallLayer(mapWorld.get(), world);
+    }
+
+    private void updateTownLayer(xyz.jpenilla.squaremap.api.MapWorld mapWorld, World world) {
+        if (!plugin.getConfig().getBoolean("settings.squaremap.show-towns")) {
+            unregisterLayer(mapWorld, TOWN_LAYER_KEY);
+            return;
+        }
+        SimpleLayerProvider provider = createLayer(
+                mapWorld,
+                TOWN_LAYER_KEY,
+                plugin.getConfig().getString("settings.squaremap.town-layer.name", "Towns"),
+                plugin.getConfig().getBoolean("settings.squaremap.town-layer.default-hidden", false),
+                plugin.getConfig().getInt("settings.squaremap.town-layer.z-index", 250),
+                plugin.getConfig().getInt("settings.squaremap.town-layer.priority", 0),
+                plugin.getConfig().getBoolean("settings.squaremap.town-layer.show-controls", true)
+        );
+        for (Town town : plugin.getTownManager().getTowns()) {
+            List<MultiPolygon.MultiPolygonPart> parts = new ArrayList<>();
+            for (ChunkKey chunk : town.getChunks()) {
+                if (!chunk.getWorld().equals(world.getName())) {
+                    continue;
+                }
+                parts.add(MultiPolygon.part(toSquarePoints(chunk.getX(), chunk.getZ())));
+            }
+            if (parts.isEmpty()) {
+                continue;
+            }
+            MultiPolygon polygon = MultiPolygon.multiPolygon(parts);
+            int color = resolveTownColor(town);
+            polygon.markerOptions(buildOptions(town.getName(), color));
+            provider.addMarker(Key.of("town_" + sanitizeKey(town.getName())), polygon);
+        }
+    }
+
+    private void updateMallLayer(xyz.jpenilla.squaremap.api.MapWorld mapWorld, World world) {
+        if (!plugin.getConfig().getBoolean("settings.squaremap.show-mall")) {
+            unregisterLayer(mapWorld, MALL_LAYER_KEY);
+            return;
+        }
+        SimpleLayerProvider provider = createLayer(
+                mapWorld,
+                MALL_LAYER_KEY,
+                plugin.getConfig().getString("settings.squaremap.mall-layer.name", "Mall"),
+                plugin.getConfig().getBoolean("settings.squaremap.mall-layer.default-hidden", false),
+                plugin.getConfig().getInt("settings.squaremap.mall-layer.z-index", 260),
+                plugin.getConfig().getInt("settings.squaremap.mall-layer.priority", 0),
+                plugin.getConfig().getBoolean("settings.squaremap.mall-layer.show-controls", true)
+        );
+        for (var entry : plugin.getMallManager().getPlots().entrySet()) {
+            int id = entry.getKey();
+            Region region = entry.getValue();
+            if (!region.getWorld().equals(world.getName())) {
+                continue;
+            }
+            List<Point> points = List.of(
+                    Point.of(region.getMinX(), region.getMinZ()),
+                    Point.of(region.getMinX(), region.getMaxZ() + 1),
+                    Point.of(region.getMaxX() + 1, region.getMaxZ() + 1),
+                    Point.of(region.getMaxX() + 1, region.getMinZ())
+            );
+            MultiPolygon polygon = MultiPolygon.multiPolygon(List.of(MultiPolygon.part(points)));
+            int color = resolveMallColor(id);
+            polygon.markerOptions(buildOptions("Mall Plot " + id, color));
+            provider.addMarker(Key.of("mall_" + id), polygon);
+        }
+    }
+
+    private SimpleLayerProvider createLayer(
+            xyz.jpenilla.squaremap.api.MapWorld mapWorld,
+            String keyName,
+            String name,
+            boolean defaultHidden,
+            int zIndex,
+            int priority,
+            boolean showControls
+    ) {
+        Key key = Key.of(keyName);
+        unregisterLayer(mapWorld, keyName);
+        SimpleLayerProvider provider = SimpleLayerProvider.builder(name)
+                .defaultHidden(defaultHidden)
+                .zIndex(zIndex)
+                .layerPriority(priority)
+                .showControls(showControls)
+                .build();
+        mapWorld.layerRegistry().register(key, provider);
+        return provider;
+    }
+
+    private void unregisterLayer(xyz.jpenilla.squaremap.api.MapWorld mapWorld, String keyName) {
+        Key key = Key.of(keyName);
+        if (mapWorld.layerRegistry().hasEntry(key)) {
+            mapWorld.layerRegistry().unregister(key);
+        }
+    }
+
+    private List<Point> toSquarePoints(int chunkX, int chunkZ) {
+        int minX = chunkX * 16;
+        int minZ = chunkZ * 16;
+        int maxX = minX + 16;
+        int maxZ = minZ + 16;
+        return List.of(
+                Point.of(minX, minZ),
+                Point.of(minX, maxZ),
+                Point.of(maxX, maxZ),
+                Point.of(maxX, minZ)
+        );
+    }
+
+    private MarkerOptions buildOptions(String label, int color) {
+        return MarkerOptions.builder()
+                .clickTooltip(label)
+                .hoverTooltip(label)
+                .fill(true)
+                .fillColor(color)
+                .fillOpacity(plugin.getConfig().getDouble("settings.squaremap.fill-opacity", 0.35))
+                .stroke(true)
+                .strokeColor(color)
+                .strokeOpacity(plugin.getConfig().getDouble("settings.squaremap.stroke-opacity", 0.8))
+                .strokeWeight(plugin.getConfig().getInt("settings.squaremap.stroke-weight", 2))
+                .build();
+    }
+
+    private String sanitizeKey(String name) {
+        return name.toLowerCase().replaceAll("[^a-z0-9_-]", "_");
+    }
+
+    private int resolveTownColor(Town town) {
+        String color = town.getMapColor();
+        if (color == null) {
+            color = plugin.getConfig().getString("settings.squaremap.town-default-color", "#00FF00");
+        }
+        return MapColorUtil.parseColor(color).orElse(0x00FF00);
+    }
+
+    private int resolveMallColor(int plotId) {
+        String color = plugin.getMallManager().getPlotColor(plotId)
+                .orElse(plugin.getConfig().getString("settings.squaremap.mall-default-color", "#FFAA00"));
+        return MapColorUtil.parseColor(color).orElse(0xFFAA00);
+    }
+}

--- a/src/main/java/com/controlbro/claimy/model/ResidentPermission.java
+++ b/src/main/java/com/controlbro/claimy/model/ResidentPermission.java
@@ -1,0 +1,10 @@
+package com.controlbro.claimy.model;
+
+public enum ResidentPermission {
+    BUILD,
+    CONTAINERS,
+    DOORS,
+    REDSTONE,
+    VILLAGERS,
+    BEDS
+}

--- a/src/main/java/com/controlbro/claimy/model/Town.java
+++ b/src/main/java/com/controlbro/claimy/model/Town.java
@@ -5,6 +5,8 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.HashMap;
+import java.util.EnumSet;
 
 public class Town {
     private final String name;
@@ -13,6 +15,8 @@ public class Town {
     private final Set<String> allies = new HashSet<>();
     private final Set<ChunkKey> chunks = new HashSet<>();
     private final Map<TownFlag, Boolean> flags = new EnumMap<>(TownFlag.class);
+    private final Map<UUID, EnumSet<ResidentPermission>> residentPermissions = new HashMap<>();
+    private String mapColor;
     private int chunkLimit;
 
     public Town(String name, UUID owner, int chunkLimit) {
@@ -49,12 +53,62 @@ public class Town {
         return flags;
     }
 
+    public Map<UUID, EnumSet<ResidentPermission>> getResidentPermissionOverrides() {
+        return residentPermissions;
+    }
+
+    public boolean isResidentPermissionEnabled(UUID uuid, ResidentPermission permission) {
+        EnumSet<ResidentPermission> permissions = residentPermissions.get(uuid);
+        if (permissions == null) {
+            return true;
+        }
+        return permissions.contains(permission);
+    }
+
+    public void setResidentPermission(UUID uuid, ResidentPermission permission, boolean value) {
+        EnumSet<ResidentPermission> permissions = residentPermissions.getOrDefault(uuid, EnumSet.allOf(ResidentPermission.class));
+        if (value) {
+            permissions.add(permission);
+        } else {
+            permissions.remove(permission);
+        }
+        if (permissions.size() == ResidentPermission.values().length) {
+            residentPermissions.remove(uuid);
+        } else {
+            residentPermissions.put(uuid, permissions);
+        }
+    }
+
+    public void setResidentPermissions(UUID uuid, EnumSet<ResidentPermission> permissions) {
+        if (permissions == null) {
+            residentPermissions.remove(uuid);
+            return;
+        }
+        if (permissions.size() == ResidentPermission.values().length) {
+            residentPermissions.remove(uuid);
+        } else {
+            residentPermissions.put(uuid, EnumSet.copyOf(permissions));
+        }
+    }
+
+    public void clearResidentPermissions(UUID uuid) {
+        residentPermissions.remove(uuid);
+    }
+
     public boolean isResident(UUID uuid) {
         return residents.contains(uuid);
     }
 
     public int getChunkLimit() {
         return chunkLimit;
+    }
+
+    public String getMapColor() {
+        return mapColor;
+    }
+
+    public void setMapColor(String mapColor) {
+        this.mapColor = mapColor;
     }
 
     public boolean isFlagEnabled(TownFlag flag) {

--- a/src/main/java/com/controlbro/claimy/util/MapColorUtil.java
+++ b/src/main/java/com/controlbro/claimy/util/MapColorUtil.java
@@ -1,0 +1,94 @@
+package com.controlbro.claimy.util;
+
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+
+public final class MapColorUtil {
+    private static final Map<String, Integer> NAMED_COLORS = new HashMap<>();
+
+    static {
+        NAMED_COLORS.put("black", 0x000000);
+        NAMED_COLORS.put("dark_gray", 0x555555);
+        NAMED_COLORS.put("gray", 0xAAAAAA);
+        NAMED_COLORS.put("light_gray", 0xD3D3D3);
+        NAMED_COLORS.put("white", 0xFFFFFF);
+        NAMED_COLORS.put("red", 0xFF0000);
+        NAMED_COLORS.put("dark_red", 0x8B0000);
+        NAMED_COLORS.put("orange", 0xFFA500);
+        NAMED_COLORS.put("yellow", 0xFFFF00);
+        NAMED_COLORS.put("gold", 0xFFD700);
+        NAMED_COLORS.put("green", 0x00AA00);
+        NAMED_COLORS.put("dark_green", 0x006400);
+        NAMED_COLORS.put("lime", 0x00FF00);
+        NAMED_COLORS.put("blue", 0x0000FF);
+        NAMED_COLORS.put("dark_blue", 0x00008B);
+        NAMED_COLORS.put("aqua", 0x00FFFF);
+        NAMED_COLORS.put("teal", 0x008080);
+        NAMED_COLORS.put("purple", 0x800080);
+        NAMED_COLORS.put("magenta", 0xFF00FF);
+        NAMED_COLORS.put("pink", 0xFFC0CB);
+        NAMED_COLORS.put("brown", 0x8B4513);
+    }
+
+    private MapColorUtil() {
+    }
+
+    public static Optional<Integer> parseColor(String colorInput) {
+        if (colorInput == null || colorInput.isBlank()) {
+            return Optional.empty();
+        }
+        String input = colorInput.trim().toLowerCase(Locale.ROOT);
+        Integer named = NAMED_COLORS.get(input);
+        if (named != null) {
+            return Optional.of(named);
+        }
+        String normalized = normalizeHex(input);
+        if (normalized == null) {
+            return Optional.empty();
+        }
+        try {
+            return Optional.of(Integer.parseInt(normalized, 16));
+        } catch (NumberFormatException ex) {
+            return Optional.empty();
+        }
+    }
+
+    public static Optional<String> normalizeColorName(String colorInput) {
+        if (colorInput == null || colorInput.isBlank()) {
+            return Optional.empty();
+        }
+        String input = colorInput.trim().toLowerCase(Locale.ROOT);
+        if (NAMED_COLORS.containsKey(input)) {
+            return Optional.of(input);
+        }
+        String normalized = normalizeHex(input);
+        if (normalized == null) {
+            return Optional.empty();
+        }
+        return Optional.of("#" + normalized.toUpperCase(Locale.ROOT));
+    }
+
+    public static Map<String, Integer> getNamedColors() {
+        return Map.copyOf(NAMED_COLORS);
+    }
+
+    private static String normalizeHex(String input) {
+        String hex = input;
+        if (hex.startsWith("#")) {
+            hex = hex.substring(1);
+        } else if (hex.startsWith("0x")) {
+            hex = hex.substring(2);
+        }
+        if (hex.length() != 6) {
+            return null;
+        }
+        for (char c : hex.toCharArray()) {
+            if (Character.digit(c, 16) == -1) {
+                return null;
+            }
+        }
+        return hex;
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -9,6 +9,27 @@ settings:
   disable-explosions-above-sea-level: true
   mall:
     require-town-for-mall-claim: false
+  squaremap:
+    enabled: true
+    show-towns: true
+    show-mall: true
+    town-default-color: "#00FF00"
+    mall-default-color: "#FFAA00"
+    fill-opacity: 0.35
+    stroke-opacity: 0.8
+    stroke-weight: 2
+    town-layer:
+      name: "Towns"
+      default-hidden: false
+      z-index: 250
+      priority: 0
+      show-controls: true
+    mall-layer:
+      name: "Mall Plots"
+      default-hidden: false
+      z-index: 260
+      priority: 0
+      show-controls: true
 messages:
   prefix: "&6[Claimy]&r "
   no-town: "&cYou are not in a town."

--- a/src/main/resources/gui.yml
+++ b/src/main/resources/gui.yml
@@ -47,3 +47,25 @@ menu:
 flags:
   title: "&6Town Flags"
   size: 27
+mall-config:
+  title: "&6Mall Plot Config"
+  size: 27
+  items:
+    add-employee:
+      slot: 11
+      material: "LIME_DYE"
+      name: "&aAdd Employee"
+      lore:
+        - "&7Click to add a player"
+    employees:
+      slot: 13
+      material: "PAPER"
+      name: "&eEmployees"
+      lore:
+        - "&7{employees}"
+    remove-employee:
+      slot: 15
+      material: "RED_DYE"
+      name: "&cRemove Employee"
+      lore:
+        - "&7Click to remove a player"

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -3,6 +3,8 @@ author: Controlbro
 main: com.controlbro.claimy.ClaimyPlugin
 version: 1.0.0
 api-version: '1.21'
+softdepend:
+  - squaremap
 commands:
   town:
     description: Town management


### PR DESCRIPTION
- Add `ResidentPermission` enum and store per-resident overrides in `Town` with load/save support in `TownManager`, plus `town resident` and `town color` commands to manage them.
- Add mall employee management and persistence in `MallManager`, an interactive config GUI `MallGui`, and `MallCommand`/tab-completion changes to manage config, employees, and per-plot colors.
- Introduce a pluggable map integration API (`MapIntegration`), a `NoopMapIntegration`, and a `SquaremapIntegration` that renders town and mall layers using `squaremap-api`, plus `MapColorUtil` to parse/normalize color names/hex codes.
- Enforce resident and mall-member rules in `ProtectionListener`, persist new fields to `towns.yml` and `mall.yml`, add `softdepend: squaremap` to `plugin.yml`, and add `squaremap-api` to `pom.xml` as an optional provided dependency.