### PR TITLE
Squaremap hover info, mall color reset, GUIs, /stuck and border fixes

### DIFF
--- a/src/main/java/com/controlbro/claimy/commands/MallTabCompleter.java
+++ b/src/main/java/com/controlbro/claimy/commands/MallTabCompleter.java
@@ -38,7 +38,7 @@ public class MallTabCompleter implements TabCompleter {
             } else if (sub.equals("color")) {
                 StringUtil.copyPartialMatches(args[1], MapColorUtil.getNamedColors().keySet(), completions);
             } else if (sub.equals("employee")) {
-                StringUtil.copyPartialMatches(args[1], List.of("add", "remove", "accept", "deny"), completions);
+                StringUtil.copyPartialMatches(args[1], List.of("add", "remove", "accept", "deny", "quit"), completions);
             }
             return completions;
         }

--- a/src/main/java/com/controlbro/claimy/commands/StuckCommand.java
+++ b/src/main/java/com/controlbro/claimy/commands/StuckCommand.java
@@ -1,6 +1,7 @@
 package com.controlbro.claimy.commands;
 
 import com.controlbro.claimy.ClaimyPlugin;
+import com.controlbro.claimy.model.ChunkKey;
 import com.controlbro.claimy.model.Town;
 import com.controlbro.claimy.util.MessageUtil;
 import org.bukkit.Location;
@@ -31,7 +32,7 @@ public class StuckCommand implements CommandExecutor {
             player.sendMessage("You are not inside a claim.");
             return true;
         }
-        Location location = findOutside(player.getLocation());
+        Location location = findOutside(player.getLocation(), townOptional.get());
         if (location == null) {
             player.sendMessage("No safe location found.");
             return true;
@@ -42,25 +43,73 @@ public class StuckCommand implements CommandExecutor {
         return true;
     }
 
-    private Location findOutside(Location location) {
+    private Location findOutside(Location location, Town town) {
         World world = location.getWorld();
         int chunkX = location.getChunk().getX();
         int chunkZ = location.getChunk().getZ();
         int blockX = location.getBlockX();
         int blockZ = location.getBlockZ();
-        int minX = chunkX << 4;
-        int minZ = chunkZ << 4;
-        int maxX = minX + 15;
-        int maxZ = minZ + 15;
-        int outsideX = blockX - minX < maxX - blockX ? minX - 1 : maxX + 1;
-        int outsideZ = blockZ - minZ < maxZ - blockZ ? minZ - 1 : maxZ + 1;
-        Location candidate = new Location(world, outsideX + 0.5, location.getY(), blockZ + 0.5);
-        if (world.getChunkAt(candidate).isLoaded()) {
-            candidate.setY(world.getHighestBlockYAt(candidate) + 1);
+        Location best = null;
+        double bestDistance = Double.MAX_VALUE;
+        double baseY = location.getY();
+        Location east = findOutsideInDirection(world, town, chunkX, chunkZ, blockX, blockZ, baseY, 1, 0);
+        best = chooseClosest(location, best, east, bestDistance);
+        if (best != null) {
+            bestDistance = best.distanceSquared(location);
+        }
+        Location west = findOutsideInDirection(world, town, chunkX, chunkZ, blockX, blockZ, baseY, -1, 0);
+        best = chooseClosest(location, best, west, bestDistance);
+        if (best != null) {
+            bestDistance = best.distanceSquared(location);
+        }
+        Location south = findOutsideInDirection(world, town, chunkX, chunkZ, blockX, blockZ, baseY, 0, 1);
+        best = chooseClosest(location, best, south, bestDistance);
+        if (best != null) {
+            bestDistance = best.distanceSquared(location);
+        }
+        Location north = findOutsideInDirection(world, town, chunkX, chunkZ, blockX, blockZ, baseY, 0, -1);
+        best = chooseClosest(location, best, north, bestDistance);
+        return best;
+    }
+
+    private Location findOutsideInDirection(World world, Town town, int chunkX, int chunkZ, int blockX, int blockZ,
+                                            double baseY, int stepX, int stepZ) {
+        String worldName = world.getName();
+        int currentX = chunkX;
+        int currentZ = chunkZ;
+        int safety = 0;
+        while (town.getChunks().contains(new ChunkKey(worldName, currentX, currentZ))) {
+            currentX += stepX;
+            currentZ += stepZ;
+            safety++;
+            if (safety > 1024) {
+                return null;
+            }
+        }
+        int lastClaimedX = currentX - stepX;
+        int lastClaimedZ = currentZ - stepZ;
+        double outsideBlockX = blockX + 0.5;
+        double outsideBlockZ = blockZ + 0.5;
+        if (stepX != 0) {
+            outsideBlockX = (lastClaimedX << 4) + (stepX > 0 ? 16 : -1) + 0.5;
+            outsideBlockZ = blockZ + 0.5;
+        } else if (stepZ != 0) {
+            outsideBlockZ = (lastClaimedZ << 4) + (stepZ > 0 ? 16 : -1) + 0.5;
+            outsideBlockX = blockX + 0.5;
+        }
+        Location candidate = new Location(world, outsideBlockX, baseY, outsideBlockZ);
+        candidate.setY(world.getHighestBlockYAt(candidate) + 1);
+        return candidate;
+    }
+
+    private Location chooseClosest(Location origin, Location currentBest, Location candidate, double bestDistance) {
+        if (candidate == null) {
+            return currentBest;
+        }
+        double distance = candidate.distanceSquared(origin);
+        if (distance < bestDistance) {
             return candidate;
         }
-        Location candidateZ = new Location(world, blockX + 0.5, location.getY(), outsideZ + 0.5);
-        candidateZ.setY(world.getHighestBlockYAt(candidateZ) + 1);
-        return candidateZ;
+        return currentBest;
     }
 }

--- a/src/main/java/com/controlbro/claimy/commands/TownAdminCommand.java
+++ b/src/main/java/com/controlbro/claimy/commands/TownAdminCommand.java
@@ -23,6 +23,7 @@ public class TownAdminCommand implements CommandExecutor {
         }
         if (args.length == 0) {
             sender.sendMessage("/townadmin reload | /townadmin mall setplot <id> | /townadmin mall clear <id>");
+            sender.sendMessage("/townadmin mallunclaim <player>");
             sender.sendMessage("Use a golden shovel to select mall region corners.");
             return true;
         }
@@ -72,6 +73,25 @@ public class TownAdminCommand implements CommandExecutor {
                 playSuccess(player);
                 return true;
             }
+        }
+        if (args[0].equalsIgnoreCase("mallunclaim")) {
+            if (args.length < 2) {
+                sender.sendMessage("/townadmin mallunclaim <player>");
+                return true;
+            }
+            String targetName = args[1];
+            var target = plugin.getServer().getOfflinePlayer(targetName);
+            if (target.getName() == null) {
+                sender.sendMessage("Player not found.");
+                return true;
+            }
+            int cleared = plugin.getMallManager().clearPlotsOwnedBy(target.getUniqueId());
+            int removed = plugin.getMallManager().removeEmployeeFromAllPlots(target.getUniqueId());
+            sender.sendMessage("Cleared " + cleared + " mall plots and removed " + removed + " employee entries.");
+            if (sender instanceof Player player) {
+                playSuccess(player);
+            }
+            return true;
         }
         return true;
     }

--- a/src/main/java/com/controlbro/claimy/commands/TownAdminTabCompleter.java
+++ b/src/main/java/com/controlbro/claimy/commands/TownAdminTabCompleter.java
@@ -21,7 +21,7 @@ public class TownAdminTabCompleter implements TabCompleter {
     public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
         List<String> completions = new ArrayList<>();
         if (args.length == 1) {
-            StringUtil.copyPartialMatches(args[0], List.of("reload", "mall"), completions);
+            StringUtil.copyPartialMatches(args[0], List.of("reload", "mall", "mallunclaim"), completions);
             return completions;
         }
         if (args.length == 2 && args[0].equalsIgnoreCase("mall")) {
@@ -33,6 +33,12 @@ public class TownAdminTabCompleter implements TabCompleter {
                     .map(String::valueOf)
                     .collect(Collectors.toList());
             StringUtil.copyPartialMatches(args[2], ids, completions);
+            return completions;
+        }
+        if (args.length == 2 && args[0].equalsIgnoreCase("mallunclaim")) {
+            StringUtil.copyPartialMatches(args[1], plugin.getServer().getOnlinePlayers().stream()
+                    .map(player -> player.getName())
+                    .collect(Collectors.toList()), completions);
             return completions;
         }
         return completions;

--- a/src/main/java/com/controlbro/claimy/commands/TownCommand.java
+++ b/src/main/java/com/controlbro/claimy/commands/TownCommand.java
@@ -411,7 +411,7 @@ public class TownCommand implements CommandExecutor {
         if (plugin.getTownManager().claimChunk(town, player.getLocation().getChunk())) {
             player.sendMessage("Chunk claimed.");
             playSuccess(player);
-            plugin.getTownGui().showClaimBorder(player, new ChunkKey(
+            plugin.getTownGui().showClaimBorder(player, town, new ChunkKey(
                     player.getWorld().getName(),
                     player.getLocation().getChunk().getX(),
                     player.getLocation().getChunk().getZ()

--- a/src/main/java/com/controlbro/claimy/gui/TownBorderRenderer.java
+++ b/src/main/java/com/controlbro/claimy/gui/TownBorderRenderer.java
@@ -15,47 +15,57 @@ public class TownBorderRenderer {
         World world = player.getWorld();
         int playerChunkX = player.getLocation().getChunk().getX();
         int playerChunkZ = player.getLocation().getChunk().getZ();
+        String worldName = world.getName();
         for (ChunkKey key : town.getChunks()) {
-            if (!key.getWorld().equals(world.getName())) {
+            if (!key.getWorld().equals(worldName)) {
                 continue;
             }
             if (Math.abs(key.getX() - playerChunkX) > 4 || Math.abs(key.getZ() - playerChunkZ) > 4) {
                 continue;
             }
-            int minX = key.getX() << 4;
-            int minZ = key.getZ() << 4;
-            int maxX = minX + 15;
-            int maxZ = minZ + 15;
-            int maxY = world.getMaxHeight();
-            for (int x = minX; x <= maxX; x++) {
-                spawnColumn(world, x, minZ, maxY, player);
-                spawnColumn(world, x, maxZ, maxY, player);
-            }
-            for (int z = minZ; z <= maxZ; z++) {
-                spawnColumn(world, minX, z, maxY, player);
-                spawnColumn(world, maxX, z, maxY, player);
-            }
+            renderEdges(player, world, town, key);
         }
     }
 
-    public static void renderChunk(Player player, ChunkKey key) {
+    public static void renderChunk(Player player, Town town, ChunkKey key) {
         World world = player.getWorld();
         if (!key.getWorld().equals(world.getName())) {
             return;
         }
+        renderEdges(player, world, town, key);
+    }
+
+    private static void renderEdges(Player player, World world, Town town, ChunkKey key) {
         int minX = key.getX() << 4;
         int minZ = key.getZ() << 4;
         int maxX = minX + 15;
         int maxZ = minZ + 15;
         int maxY = world.getMaxHeight();
-        for (int x = minX; x <= maxX; x++) {
-            spawnColumn(world, x, minZ, maxY, player);
-            spawnColumn(world, x, maxZ, maxY, player);
+        String worldName = key.getWorld();
+        if (!isClaimed(town, worldName, key.getX(), key.getZ() - 1)) {
+            for (int x = minX; x <= maxX; x++) {
+                spawnColumn(world, x, minZ, maxY, player);
+            }
         }
-        for (int z = minZ; z <= maxZ; z++) {
-            spawnColumn(world, minX, z, maxY, player);
-            spawnColumn(world, maxX, z, maxY, player);
+        if (!isClaimed(town, worldName, key.getX(), key.getZ() + 1)) {
+            for (int x = minX; x <= maxX; x++) {
+                spawnColumn(world, x, maxZ, maxY, player);
+            }
         }
+        if (!isClaimed(town, worldName, key.getX() - 1, key.getZ())) {
+            for (int z = minZ; z <= maxZ; z++) {
+                spawnColumn(world, minX, z, maxY, player);
+            }
+        }
+        if (!isClaimed(town, worldName, key.getX() + 1, key.getZ())) {
+            for (int z = minZ; z <= maxZ; z++) {
+                spawnColumn(world, maxX, z, maxY, player);
+            }
+        }
+    }
+
+    private static boolean isClaimed(Town town, String world, int x, int z) {
+        return town.getChunks().contains(new ChunkKey(world, x, z));
     }
 
     private static void spawnColumn(World world, int x, int z, int maxY, Player player) {

--- a/src/main/java/com/controlbro/claimy/gui/TownGui.java
+++ b/src/main/java/com/controlbro/claimy/gui/TownGui.java
@@ -2,6 +2,7 @@ package com.controlbro.claimy.gui;
 
 import com.controlbro.claimy.ClaimyPlugin;
 import com.controlbro.claimy.model.ChunkKey;
+import com.controlbro.claimy.model.ResidentPermission;
 import com.controlbro.claimy.model.Town;
 import com.controlbro.claimy.model.TownFlag;
 import com.controlbro.claimy.util.MessageUtil;
@@ -17,10 +18,12 @@ import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.inventory.meta.SkullMeta;
 
 import java.io.File;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -31,6 +34,8 @@ public class TownGui implements Listener {
     private final ClaimyPlugin plugin;
     private YamlConfiguration guiConfig;
     private final Map<UUID, Integer> borderTasks = new HashMap<>();
+    private final Map<UUID, Map<Integer, UUID>> residentSlots = new HashMap<>();
+    private final Map<UUID, ResidentPermissionContext> residentPermissionContexts = new HashMap<>();
 
     public TownGui(ClaimyPlugin plugin) {
         this.plugin = plugin;
@@ -91,6 +96,121 @@ public class TownGui implements Listener {
         player.openInventory(inventory);
     }
 
+    public void openResidents(Player player, Town town) {
+        if (!town.getOwner().equals(player.getUniqueId()) && !player.hasPermission("claimy.admin")) {
+            player.sendMessage("Only the town owner can manage residents.");
+            return;
+        }
+        ConfigurationSection section = guiConfig.getConfigurationSection("residents");
+        if (section == null) {
+            player.sendMessage("Resident menu is missing from gui.yml.");
+            return;
+        }
+        String title = MessageUtil.color(section.getString("title", "Residents"));
+        int size = section.getInt("size", 54);
+        Inventory inventory = Bukkit.createInventory(player, size, title);
+        ConfigurationSection items = section.getConfigurationSection("items");
+        HashSet<Integer> reservedSlots = new HashSet<>();
+        if (items != null) {
+            for (String key : items.getKeys(false)) {
+                ConfigurationSection itemSection = items.getConfigurationSection(key);
+                if (itemSection == null) {
+                    continue;
+                }
+                int slot = itemSection.getInt("slot");
+                reservedSlots.add(slot);
+                Material material = Material.matchMaterial(itemSection.getString("material", "STONE"));
+                ItemStack stack = new ItemStack(material == null ? Material.STONE : material);
+                ItemMeta meta = stack.getItemMeta();
+                meta.setDisplayName(MessageUtil.color(itemSection.getString("name", key)));
+                List<String> lore = new ArrayList<>();
+                for (String line : itemSection.getStringList("lore")) {
+                    lore.add(MessageUtil.color(line));
+                }
+                meta.setLore(lore);
+                stack.setItemMeta(meta);
+                inventory.setItem(slot, stack);
+            }
+        }
+        Map<Integer, UUID> slots = new HashMap<>();
+        List<UUID> residents = new ArrayList<>(town.getResidents());
+        residents.sort((a, b) -> {
+            String nameA = Optional.ofNullable(Bukkit.getOfflinePlayer(a).getName()).orElse(a.toString());
+            String nameB = Optional.ofNullable(Bukkit.getOfflinePlayer(b).getName()).orElse(b.toString());
+            return nameA.compareToIgnoreCase(nameB);
+        });
+        int slot = 0;
+        for (UUID residentId : residents) {
+            while (slot < size && reservedSlots.contains(slot)) {
+                slot++;
+            }
+            if (slot >= size) {
+                break;
+            }
+            ItemStack head = new ItemStack(Material.PLAYER_HEAD);
+            SkullMeta meta = (SkullMeta) head.getItemMeta();
+            meta.setOwningPlayer(Bukkit.getOfflinePlayer(residentId));
+            String name = Optional.ofNullable(Bukkit.getOfflinePlayer(residentId).getName()).orElse("Unknown");
+            meta.setDisplayName(MessageUtil.color("&e" + name));
+            meta.setLore(List.of(
+                    MessageUtil.color("&7Click to edit permissions.")
+            ));
+            head.setItemMeta(meta);
+            inventory.setItem(slot, head);
+            slots.put(slot, residentId);
+            slot++;
+        }
+        residentSlots.put(player.getUniqueId(), slots);
+        player.openInventory(inventory);
+    }
+
+    public void openResidentPermissions(Player player, Town town, UUID residentId) {
+        if (!town.getOwner().equals(player.getUniqueId()) && !player.hasPermission("claimy.admin")) {
+            player.sendMessage("Only the town owner can manage residents.");
+            return;
+        }
+        ConfigurationSection section = guiConfig.getConfigurationSection("resident-permissions");
+        if (section == null) {
+            player.sendMessage("Resident permissions menu is missing from gui.yml.");
+            return;
+        }
+        String residentName = Optional.ofNullable(Bukkit.getOfflinePlayer(residentId).getName()).orElse("Resident");
+        String title = MessageUtil.color(section.getString("title", "Resident Permissions")
+                .replace("{resident}", residentName));
+        int size = section.getInt("size", 27);
+        Inventory inventory = Bukkit.createInventory(player, size, title);
+        ConfigurationSection items = section.getConfigurationSection("items");
+        if (items != null) {
+            for (String key : items.getKeys(false)) {
+                ConfigurationSection itemSection = items.getConfigurationSection(key);
+                if (itemSection == null) {
+                    continue;
+                }
+                int itemSlot = itemSection.getInt("slot");
+                Material material = Material.matchMaterial(itemSection.getString("material", "STONE"));
+                ItemStack stack = new ItemStack(material == null ? Material.STONE : material);
+                ItemMeta meta = stack.getItemMeta();
+                meta.setDisplayName(MessageUtil.color(itemSection.getString("name", key)));
+                List<String> lore = new ArrayList<>();
+                Optional<ResidentPermission> permission = parsePermissionKey(key);
+                String status = "N/A";
+                if (permission.isPresent()) {
+                    boolean allowed = town.isResidentPermissionEnabled(residentId, permission.get());
+                    status = allowed ? "Allowed" : "Denied";
+                }
+                for (String line : itemSection.getStringList("lore")) {
+                    lore.add(MessageUtil.color(line.replace("{status}", status)));
+                }
+                meta.setLore(lore);
+                stack.setItemMeta(meta);
+                inventory.setItem(itemSlot, stack);
+            }
+        }
+        residentPermissionContexts.put(player.getUniqueId(),
+                new ResidentPermissionContext(town.getName(), residentId));
+        player.openInventory(inventory);
+    }
+
     public void showBorder(Player player, Town town) {
         if (!plugin.getConfig().getBoolean("settings.show-border-particles")) {
             return;
@@ -110,7 +230,7 @@ public class TownGui implements Listener {
         taskIdHolder[0] = taskId;
     }
 
-    public void showClaimBorder(Player player, ChunkKey chunkKey) {
+    public void showClaimBorder(Player player, Town town, ChunkKey chunkKey) {
         if (!plugin.getConfig().getBoolean("settings.show-border-particles")) {
             return;
         }
@@ -123,7 +243,7 @@ public class TownGui implements Listener {
                 plugin.getServer().getScheduler().cancelTask(taskIdHolder[0]);
                 return;
             }
-            TownBorderRenderer.renderChunk(player, chunkKey);
+            TownBorderRenderer.renderChunk(player, town, chunkKey);
             remaining[0]--;
         }, 0L, interval);
         taskIdHolder[0] = taskId;
@@ -164,25 +284,118 @@ public class TownGui implements Listener {
             if (event.getCurrentItem() == null) {
                 return;
             }
-            String display = event.getCurrentItem().getItemMeta() != null
-                    ? event.getCurrentItem().getItemMeta().getDisplayName()
-                    : "";
-            if (display.contains("Create")) {
-                player.sendMessage("Use /town create <name>");
-            } else if (display.contains("Delete")) {
-                player.sendMessage("Use /town delete");
-            } else if (display.contains("Invite")) {
-                player.sendMessage("Use /town invite <player>");
-            } else if (display.contains("Kick")) {
-                player.sendMessage("Use /town kick <player>");
-            } else if (display.contains("Border")) {
-                Optional<Town> townOptional = plugin.getTownManager().getTown(player.getUniqueId());
-                townOptional.ifPresent(town -> showBorder(player, town));
-            } else if (display.contains("Flags")) {
-                Optional<Town> townOptional = plugin.getTownManager().getTown(player.getUniqueId());
-                townOptional.ifPresent(town -> openFlags(player, town));
-            } else if (display.contains("Ally")) {
-                player.sendMessage("Use /town ally <town>");
+            ConfigurationSection items = guiConfig.getConfigurationSection("menu.items");
+            if (items == null) {
+                return;
+            }
+            int slot = event.getSlot();
+            for (String key : items.getKeys(false)) {
+                ConfigurationSection itemSection = items.getConfigurationSection(key);
+                if (itemSection == null) {
+                    continue;
+                }
+                if (itemSection.getInt("slot") != slot) {
+                    continue;
+                }
+                switch (key.toLowerCase(Locale.ROOT)) {
+                    case "create" -> player.sendMessage("Use /town create <name>");
+                    case "delete" -> player.sendMessage("Use /town delete");
+                    case "invite" -> player.sendMessage("Use /town invite <player>");
+                    case "kick" -> player.sendMessage("Use /town kick <player>");
+                    case "border" -> plugin.getTownManager().getTown(player.getUniqueId())
+                            .ifPresent(town -> showBorder(player, town));
+                    case "flags" -> plugin.getTownManager().getTown(player.getUniqueId())
+                            .ifPresent(town -> openFlags(player, town));
+                    case "ally" -> player.sendMessage("Use /town ally <town>");
+                    case "residents" -> plugin.getTownManager().getTown(player.getUniqueId())
+                            .ifPresent(town -> openResidents(player, town));
+                    default -> {
+                    }
+                }
+                return;
+            }
+        }
+        if (title.equals(MessageUtil.color(guiConfig.getString("residents.title", "Residents")))) {
+            event.setCancelled(true);
+            if (event.getCurrentItem() == null) {
+                return;
+            }
+            ConfigurationSection section = guiConfig.getConfigurationSection("residents");
+            if (section == null) {
+                return;
+            }
+            ConfigurationSection items = section.getConfigurationSection("items");
+            int slot = event.getSlot();
+            if (items != null) {
+                for (String key : items.getKeys(false)) {
+                    ConfigurationSection itemSection = items.getConfigurationSection(key);
+                    if (itemSection == null) {
+                        continue;
+                    }
+                    if (itemSection.getInt("slot") == slot && key.equalsIgnoreCase("back")) {
+                        openMain(player);
+                        return;
+                    }
+                }
+            }
+            Map<Integer, UUID> slots = residentSlots.get(player.getUniqueId());
+            if (slots == null) {
+                return;
+            }
+            UUID residentId = slots.get(slot);
+            if (residentId == null) {
+                return;
+            }
+            plugin.getTownManager().getTown(player.getUniqueId())
+                    .ifPresent(town -> openResidentPermissions(player, town, residentId));
+        }
+        ConfigurationSection residentPermissionsSection = guiConfig.getConfigurationSection("resident-permissions");
+        String residentTitlePrefix = "Resident Permissions";
+        if (residentPermissionsSection != null) {
+            residentTitlePrefix = residentPermissionsSection.getString("title", "Resident Permissions")
+                    .replace("{resident}", "");
+        }
+        if (title.startsWith(MessageUtil.color(residentTitlePrefix))) {
+            event.setCancelled(true);
+            if (event.getCurrentItem() == null) {
+                return;
+            }
+            ResidentPermissionContext context = residentPermissionContexts.get(player.getUniqueId());
+            if (context == null) {
+                return;
+            }
+            Optional<Town> townOptional = plugin.getTownManager().getTown(context.townName);
+            if (townOptional.isEmpty()) {
+                return;
+            }
+            Town town = townOptional.get();
+            ConfigurationSection items = residentPermissionsSection != null
+                    ? residentPermissionsSection.getConfigurationSection("items")
+                    : null;
+            if (items == null) {
+                return;
+            }
+            int slot = event.getSlot();
+            for (String key : items.getKeys(false)) {
+                ConfigurationSection itemSection = items.getConfigurationSection(key);
+                if (itemSection == null) {
+                    continue;
+                }
+                if (itemSection.getInt("slot") != slot) {
+                    continue;
+                }
+                if (key.equalsIgnoreCase("back")) {
+                    openResidents(player, town);
+                    return;
+                }
+                Optional<ResidentPermission> permission = parsePermissionKey(key);
+                if (permission.isPresent()) {
+                    boolean allowed = town.isResidentPermissionEnabled(context.residentId, permission.get());
+                    town.setResidentPermission(context.residentId, permission.get(), !allowed);
+                    plugin.getTownManager().save();
+                    openResidentPermissions(player, town, context.residentId);
+                }
+                return;
             }
         }
         if (title.equals(MessageUtil.color(guiConfig.getString("flags.title", "Flags")))) {
@@ -208,5 +421,16 @@ public class TownGui implements Listener {
                 // ignore
             }
         }
+    }
+
+    private Optional<ResidentPermission> parsePermissionKey(String key) {
+        try {
+            return Optional.of(ResidentPermission.valueOf(key.toUpperCase(Locale.ROOT)));
+        } catch (IllegalArgumentException ex) {
+            return Optional.empty();
+        }
+    }
+
+    private record ResidentPermissionContext(String townName, UUID residentId) {
     }
 }

--- a/src/main/java/com/controlbro/claimy/listeners/ProtectionListener.java
+++ b/src/main/java/com/controlbro/claimy/listeners/ProtectionListener.java
@@ -339,7 +339,7 @@ public class ProtectionListener implements Listener {
                 player.sendMessage("Chunk claimed.");
             }
             playSuccess(player);
-            plugin.getTownGui().showClaimBorder(player,
+            plugin.getTownGui().showClaimBorder(player, town,
                     new ChunkKey(chunk.getWorld().getName(), chunk.getX(), chunk.getZ()));
             return true;
         }

--- a/src/main/java/com/controlbro/claimy/managers/MallManager.java
+++ b/src/main/java/com/controlbro/claimy/managers/MallManager.java
@@ -135,6 +135,9 @@ public class MallManager {
         if (plotOwners.containsKey(id)) {
             return false;
         }
+        if (isPlotOwner(playerId)) {
+            return false;
+        }
         if (isEmployee(playerId)) {
             return false;
         }
@@ -174,9 +177,44 @@ public class MallManager {
     public void clearPlotOwner(int id) {
         plotOwners.remove(id);
         plotEmployees.remove(id);
+        plotColors.remove(id);
         employeeRequests.values().removeIf(value -> value == id);
         save();
         plugin.getMapIntegration().refreshAll();
+    }
+
+    public int clearPlotsOwnedBy(UUID ownerId) {
+        List<Integer> ownedPlots = new ArrayList<>();
+        for (Map.Entry<Integer, UUID> entry : plotOwners.entrySet()) {
+            if (entry.getValue().equals(ownerId)) {
+                ownedPlots.add(entry.getKey());
+            }
+        }
+        for (int plotId : ownedPlots) {
+            plotOwners.remove(plotId);
+            plotEmployees.remove(plotId);
+            plotColors.remove(plotId);
+            employeeRequests.values().removeIf(value -> value == plotId);
+        }
+        if (!ownedPlots.isEmpty()) {
+            save();
+            plugin.getMapIntegration().refreshAll();
+        }
+        return ownedPlots.size();
+    }
+
+    public int removeEmployeeFromAllPlots(UUID employeeId) {
+        int removed = 0;
+        for (Map.Entry<Integer, Set<UUID>> entry : plotEmployees.entrySet()) {
+            if (entry.getValue().remove(employeeId)) {
+                removed++;
+            }
+        }
+        employeeRequests.remove(employeeId);
+        if (removed > 0) {
+            save();
+        }
+        return removed;
     }
 
     public boolean addEmployee(int id, UUID employeeId) {

--- a/src/main/resources/gui.yml
+++ b/src/main/resources/gui.yml
@@ -1,6 +1,6 @@
 menu:
-  title: "&6Town Menu"
-  size: 27
+  title: "&6Town Control Center"
+  size: 36
   items:
     create:
       slot: 10
@@ -38,8 +38,14 @@ menu:
       name: "&6Town Flags"
       lore:
         - "&7Click to edit flags"
-    ally:
+    residents:
       slot: 16
+      material: "PLAYER_HEAD"
+      name: "&dResidents"
+      lore:
+        - "&7Manage resident permissions"
+    ally:
+      slot: 22
       material: "TOTEM_OF_UNDYING"
       name: "&dAlly Town"
       lore:
@@ -47,8 +53,70 @@ menu:
 flags:
   title: "&6Town Flags"
   size: 27
+residents:
+  title: "&6Town Residents"
+  size: 54
+  items:
+    back:
+      slot: 49
+      material: "ARROW"
+      name: "&7Back"
+      lore:
+        - "&7Return to the town menu"
+resident-permissions:
+  title: "&6Resident Permissions: {resident}"
+  size: 27
+  items:
+    build:
+      slot: 10
+      material: "STONE_BRICKS"
+      name: "&aBuild"
+      lore:
+        - "&7Status: {status}"
+        - "&7Click to toggle"
+    containers:
+      slot: 11
+      material: "CHEST"
+      name: "&eContainers"
+      lore:
+        - "&7Status: {status}"
+        - "&7Click to toggle"
+    doors:
+      slot: 12
+      material: "OAK_DOOR"
+      name: "&6Doors"
+      lore:
+        - "&7Status: {status}"
+        - "&7Click to toggle"
+    redstone:
+      slot: 13
+      material: "REDSTONE"
+      name: "&cRedstone"
+      lore:
+        - "&7Status: {status}"
+        - "&7Click to toggle"
+    villagers:
+      slot: 14
+      material: "EMERALD"
+      name: "&aVillagers"
+      lore:
+        - "&7Status: {status}"
+        - "&7Click to toggle"
+    beds:
+      slot: 15
+      material: "RED_BED"
+      name: "&dBeds"
+      lore:
+        - "&7Status: {status}"
+        - "&7Click to toggle"
+    back:
+      slot: 22
+      material: "ARROW"
+      name: "&7Back"
+      lore:
+        - "&7Return to residents"
 mall-config:
-  title: "&6Mall Plot Config"
+  title: "&6Mall Owner Panel"
   size: 27
   items:
     add-employee:
@@ -69,3 +137,13 @@ mall-config:
       name: "&cRemove Employee"
       lore:
         - "&7Click to remove a player"
+mall-employee:
+  title: "&6Mall Employee Panel"
+  size: 27
+  items:
+    quit-store:
+      slot: 13
+      material: "BARRIER"
+      name: "&cQuit Store"
+      lore:
+        - "&7Leave this mall plot"


### PR DESCRIPTION
- Map: updated `SquaremapIntegration` to build richer hover labels via `buildTownLabel` and `buildMallLabel`, showing owners, residents, allies, and employees and using `Open Plot` for unowned mall plots.
- Mall ownership: `MallManager` now clears `plotColors` in `clearPlotOwner`, adds `clearPlotsOwnedBy` and `removeEmployeeFromAllPlots`, and prevents a player from owning multiple plots or being both owner and employee.
- GUIs & commands: added owner vs employee mall panels in `MallGui` (`openConfig` / `openEmployee`) and `gui.yml` changes, added employee `quit` handling in `MallCommand` and tab completers, and added admin `mallunclaim` in `TownAdminCommand`.
- Town behavior & rendering: `StuckCommand` now searches outward across the whole town and selects the nearest safe exit, `TownBorderRenderer` renders only exterior chunk edges via `renderEdges` and `isClaimed` and `renderChunk` now accepts a `Town`, and `TownGui` gained residents and resident-permissions menus with head-click listing and toggles.