### PR TITLE
Add town assistants, plots/outposts, build modes, and color GUIs

### DIFF
--- a/src/main/java/com/controlbro/claimy/commands/TownTabCompleter.java
+++ b/src/main/java/com/controlbro/claimy/commands/TownTabCompleter.java
@@ -22,7 +22,7 @@ import java.util.stream.Collectors;
 public class TownTabCompleter implements TabCompleter {
     private static final List<String> SUBCOMMANDS = Arrays.asList(
             "create", "delete", "invite", "accept", "kick", "flag", "border", "help", "ally", "unally", "claim",
-            "resident", "color"
+            "resident", "color", "assistant", "buildmode", "outpost", "plot"
     );
 
     private final ClaimyPlugin plugin;
@@ -84,6 +84,18 @@ public class TownTabCompleter implements TabCompleter {
                         }
                     }
                 }
+                case "assistant" -> {
+                    StringUtil.copyPartialMatches(args[1], List.of("add", "remove"), completions);
+                }
+                case "buildmode" -> {
+                    StringUtil.copyPartialMatches(args[1], List.of("open", "plot"), completions);
+                }
+                case "outpost" -> {
+                    StringUtil.copyPartialMatches(args[1], List.of("create", "claim"), completions);
+                }
+                case "plot" -> {
+                    StringUtil.copyPartialMatches(args[1], List.of("create", "claim", "unclaim", "cancel"), completions);
+                }
                 case "color" -> {
                     StringUtil.copyPartialMatches(args[1], MapColorUtil.getNamedColors().keySet(), completions);
                 }
@@ -109,6 +121,17 @@ public class TownTabCompleter implements TabCompleter {
                         .map(permission -> permission.name().toLowerCase(Locale.ROOT))
                         .collect(Collectors.toList());
                 StringUtil.copyPartialMatches(args[2], permissions, completions);
+            }
+            if ("assistant".equals(sub) && sender instanceof Player player) {
+                Optional<Town> town = plugin.getTownManager().getTown(player.getUniqueId());
+                if (town.isPresent()) {
+                    List<String> names = town.get().getResidents().stream()
+                            .map(Bukkit::getOfflinePlayer)
+                            .map(offline -> offline.getName() == null ? "" : offline.getName())
+                            .filter(name -> !name.isBlank())
+                            .collect(Collectors.toList());
+                    StringUtil.copyPartialMatches(args[2], names, completions);
+                }
             }
         }
         if (args.length == 4 && "resident".equals(sub)) {

--- a/src/main/java/com/controlbro/claimy/model/Town.java
+++ b/src/main/java/com/controlbro/claimy/model/Town.java
@@ -7,16 +7,22 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.HashMap;
 import java.util.EnumSet;
+import java.util.Optional;
 
 public class Town {
     private final String name;
     private final UUID owner;
     private final Set<UUID> residents = new HashSet<>();
+    private final Set<UUID> assistants = new HashSet<>();
     private final Set<String> allies = new HashSet<>();
     private final Set<ChunkKey> chunks = new HashSet<>();
+    private final Set<ChunkKey> outpostChunks = new HashSet<>();
+    private final Map<Integer, Region> plots = new HashMap<>();
+    private final Map<Integer, UUID> plotOwners = new HashMap<>();
     private final Map<TownFlag, Boolean> flags = new EnumMap<>(TownFlag.class);
     private final Map<UUID, EnumSet<ResidentPermission>> residentPermissions = new HashMap<>();
     private String mapColor;
+    private TownBuildMode buildMode = TownBuildMode.OPEN_TOWN;
     private int chunkLimit;
 
     public Town(String name, UUID owner, int chunkLimit) {
@@ -41,12 +47,28 @@ public class Town {
         return residents;
     }
 
+    public Set<UUID> getAssistants() {
+        return assistants;
+    }
+
     public Set<String> getAllies() {
         return allies;
     }
 
     public Set<ChunkKey> getChunks() {
         return chunks;
+    }
+
+    public Set<ChunkKey> getOutpostChunks() {
+        return outpostChunks;
+    }
+
+    public Map<Integer, Region> getPlots() {
+        return plots;
+    }
+
+    public Map<Integer, UUID> getPlotOwners() {
+        return plotOwners;
     }
 
     public Map<TownFlag, Boolean> getFlags() {
@@ -99,6 +121,10 @@ public class Town {
         return residents.contains(uuid);
     }
 
+    public boolean isAssistant(UUID uuid) {
+        return assistants.contains(uuid);
+    }
+
     public int getChunkLimit() {
         return chunkLimit;
     }
@@ -111,11 +137,51 @@ public class Town {
         this.mapColor = mapColor;
     }
 
+    public TownBuildMode getBuildMode() {
+        return buildMode;
+    }
+
+    public void setBuildMode(TownBuildMode buildMode) {
+        this.buildMode = buildMode;
+    }
+
     public boolean isFlagEnabled(TownFlag flag) {
         return flags.getOrDefault(flag, false);
     }
 
     public void setFlag(TownFlag flag, boolean value) {
         flags.put(flag, value);
+    }
+
+    public void addAssistant(UUID uuid) {
+        assistants.add(uuid);
+    }
+
+    public void removeAssistant(UUID uuid) {
+        assistants.remove(uuid);
+    }
+
+    public void addOutpostChunk(ChunkKey chunkKey) {
+        outpostChunks.add(chunkKey);
+    }
+
+    public void removeOutpostChunk(ChunkKey chunkKey) {
+        outpostChunks.remove(chunkKey);
+    }
+
+    public Optional<UUID> getPlotOwner(int plotId) {
+        return Optional.ofNullable(plotOwners.get(plotId));
+    }
+
+    public void claimPlot(int plotId, UUID ownerId) {
+        plotOwners.put(plotId, ownerId);
+    }
+
+    public void unclaimPlot(int plotId) {
+        plotOwners.remove(plotId);
+    }
+
+    public void removePlotsOwnedBy(UUID ownerId) {
+        plotOwners.entrySet().removeIf(entry -> entry.getValue().equals(ownerId));
     }
 }

--- a/src/main/java/com/controlbro/claimy/model/TownBuildMode.java
+++ b/src/main/java/com/controlbro/claimy/model/TownBuildMode.java
@@ -1,0 +1,6 @@
+package com.controlbro.claimy.model;
+
+public enum TownBuildMode {
+    OPEN_TOWN,
+    PLOT_ONLY
+}

--- a/src/main/java/com/controlbro/claimy/util/MapColorUtil.java
+++ b/src/main/java/com/controlbro/claimy/util/MapColorUtil.java
@@ -4,6 +4,7 @@ import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+import org.bukkit.Material;
 
 public final class MapColorUtil {
     private static final Map<String, Integer> NAMED_COLORS = new HashMap<>();
@@ -72,6 +73,29 @@ public final class MapColorUtil {
 
     public static Map<String, Integer> getNamedColors() {
         return Map.copyOf(NAMED_COLORS);
+    }
+
+    public static Material getDyeMaterial(String colorName) {
+        if (colorName == null) {
+            return Material.WHITE_DYE;
+        }
+        return switch (colorName.toLowerCase(Locale.ROOT)) {
+            case "black" -> Material.BLACK_DYE;
+            case "dark_gray", "gray" -> Material.GRAY_DYE;
+            case "light_gray" -> Material.LIGHT_GRAY_DYE;
+            case "white" -> Material.WHITE_DYE;
+            case "red", "dark_red" -> Material.RED_DYE;
+            case "orange", "gold" -> Material.ORANGE_DYE;
+            case "yellow" -> Material.YELLOW_DYE;
+            case "green", "dark_green" -> Material.GREEN_DYE;
+            case "lime" -> Material.LIME_DYE;
+            case "blue", "dark_blue" -> Material.BLUE_DYE;
+            case "aqua", "teal" -> Material.CYAN_DYE;
+            case "purple", "magenta" -> Material.MAGENTA_DYE;
+            case "pink" -> Material.PINK_DYE;
+            case "brown" -> Material.BROWN_DYE;
+            default -> Material.WHITE_DYE;
+        };
     }
 
     private static String normalizeHex(String input) {

--- a/src/main/resources/gui.yml
+++ b/src/main/resources/gui.yml
@@ -50,9 +50,18 @@ menu:
       name: "&dAlly Town"
       lore:
         - "&7Use /town ally <town>"
+    color:
+      slot: 23
+      material: "LIME_DYE"
+      name: "&aTown Color"
+      lore:
+        - "&7Click to set the town color"
 flags:
   title: "&6Town Flags"
   size: 27
+colors:
+  title: "&6Town Colors"
+  size: 54
 residents:
   title: "&6Town Residents"
   size: 54
@@ -125,6 +134,12 @@ mall-config:
       name: "&aAdd Employee"
       lore:
         - "&7Click to add a player"
+    color:
+      slot: 12
+      material: "LIME_DYE"
+      name: "&aSet Plot Color"
+      lore:
+        - "&7Click to set the plot color"
     employees:
       slot: 13
       material: "PAPER"
@@ -137,6 +152,9 @@ mall-config:
       name: "&cRemove Employee"
       lore:
         - "&7Click to remove a player"
+mall-colors:
+  title: "&6Mall Plot Colors"
+  size: 54
 mall-employee:
   title: "&6Mall Employee Panel"
   size: 27


### PR DESCRIPTION

- Data model and persistence: extended `Town` with `assistants`, `outpostChunks`, `plots`, `plotOwners`, and a `TownBuildMode`, and saved/loaded these fields from `towns.yml` in `TownManager`.
- Commands & tab completion: added ` /town assistant ...`, ` /town buildmode ...`, ` /town outpost ...`, and ` /town plot ...` handlers and hooked them into `TownTabCompleter` and `TownCommand` for plot creation/claiming and outpost management.
- Protection and selection: added plot selection state and preview rendering in `TownManager`, golden-shovel plot selection handling in `ProtectionListener`, and protection checks so assistants and plot owners bypass restrictions while residents respect `buildMode` and plot ownership.
- UI & map: added town color and mall-plot color GUIs (dye palette) in `TownGui` and `MallGui`, added `MapColorUtil.getDyeMaterial`, and updated `SquaremapIntegration` to render outposts as a separate labeled layer.